### PR TITLE
Use IRIs instead of semantically-named blank node identifiers

### DIFF
--- a/index.html
+++ b/index.html
@@ -2538,7 +2538,7 @@ specified. The full <a>IRI</a> for
       "name": "http://xmlns.com/foaf/0.1/name",
       "knows": "http://xmlns.com/foaf/0.1/knows"
     },
-    ****"@id": "_:graph",
+    ****"@id": "http://example.org/foaf-graph",
     "generatedAt": "2012-04-09",
     "@graph":**** [
       {
@@ -2558,7 +2558,7 @@ specified. The full <a>IRI</a> for
   </pre>
 
   <p>The example above expresses a <a>named graph</a> that is identified
-    by the <a>Blank Node identifier</a> <code>_:graph</code>. That
+    by the <a>IRI</a> <code>http://example.org/foaf-graph</code>. That
     graph is composed of the statements about Manu and Gregg. Metadata about
     the graph itself is expressed via the <code>generatedAt</code> property,
     which specifies when the graph was generated. An alternative view of the
@@ -2575,48 +2575,48 @@ specified. The full <a>IRI</a> for
   <tbody>
   <tr>
     <td>&nbsp;</td>
-    <td>_:graph</td>
+    <td>http://example.org/foaf-graph</td>
     <td>prov:generatedAtTime</td>
     <td>2012-04-09</td>
     <td>xsd:date</td>
   </tr>
   <tr>
-    <td>_:graph</td>
+    <td>http://example.org/foaf-graph</td>
     <td>http://manu.sporny.org/about#manu</td>
     <td>xsd:type</td>
     <td>foaf:Person</td>
     <td></td>
   </tr>
   <tr>
-    <td>_:graph</td>
+    <td>http://example.org/foaf-graph</td>
     <td>http://manu.sporny.org/about#manu</td>
     <td>foaf:name</td>
     <td>Manu Sporny</td>
     <td></td>
   </tr>
   <tr>
-    <td>_:graph</td>
+    <td>http://example.org/foaf-graph</td>
     <td>http://manu.sporny.org/about#manu</td>
     <td>foaf:knows</td>
     <td>http://greggkellogg.net/foaf#me</td>
     <td></td>
   </tr>
   <tr>
-    <td>_:graph</td>
+    <td>http://example.org/foaf-graph</td>
     <td>http://greggkellogg.net/foaf#me</td>
     <td>xsd:type</td>
     <td>foaf:Person</td>
     <td></td>
   </tr>
   <tr>
-    <td>_:graph</td>
+    <td>http://example.org/foaf-graph</td>
     <td>http://greggkellogg.net/foaf#me</td>
     <td>foaf:name</td>
     <td>Gregg Kellogg</td>
     <td></td>
   </tr>
   <tr>
-    <td>_:graph</td>
+    <td>http://example.org/foaf-graph</td>
     <td>http://greggkellogg.net/foaf#me</td>
     <td>foaf:knows</td>
     <td>http://manu.sporny.org/about#manu</td>
@@ -2724,8 +2724,9 @@ specified. The full <a>IRI</a> for
           "@container": "@graph"
         }****
       },
-      ****"generatedAt": "2012-04-09",
-      "claim": [****
+      "@id": "http://example.org/foaf-graph",
+      "generatedAt": "2012-04-09",
+      ****"claim": [****
         {
           "@id": "http://manu.sporny.org/about#manu",
           "@type": "Person",
@@ -2743,7 +2744,7 @@ specified. The full <a>IRI</a> for
     </pre>
 
     <p>The example above expresses a <a>named graph</a> that is identified
-      by the <a>blank node identifier</a> <code>_:claim</code>. That
+      by the <a>blank node identifier</a> <code>_:b0</code>. That
       graph is composed of the statements about Manu and Gregg. Metadata about
       the graph itself is expressed via the <code>generatedAt</code> property,
       which specifies when the graph was generated. An alternative view of the
@@ -2760,55 +2761,55 @@ specified. The full <a>IRI</a> for
     <tbody>
     <tr>
       <td>&nbsp;</td>
-      <td>_:metadata</td>
+      <td>http://example.org/foaf-graph</td>
       <td>prov:generatedAtTime</td>
       <td>2012-04-09</td>
       <td>xsd:date</td>
     </tr>
     <tr>
       <td>&nbsp;</td>
-      <td>_:metadata</td>
+      <td>http://example.org/foaf-graph</td>
       <td>cred:claim</td>
-      <td>_:claim</td>
+      <td>_:b0</td>
       <td></td>
     </tr>
     <tr>
-      <td>_:claim</td>
+      <td>_:b0</td>
       <td>http://manu.sporny.org/about#manu</td>
       <td>xsd:type</td>
       <td>foaf:Person</td>
       <td></td>
     </tr>
     <tr>
-      <td>_:claim</td>
+      <td>_:b0</td>
       <td>http://manu.sporny.org/about#manu</td>
       <td>foaf:name</td>
       <td>Manu Sporny</td>
       <td></td>
     </tr>
     <tr>
-      <td>_:claim</td>
+      <td>_:b0</td>
       <td>http://manu.sporny.org/about#manu</td>
       <td>foaf:knows</td>
       <td>http://greggkellogg.net/foaf#me</td>
       <td></td>
     </tr>
     <tr>
-      <td>_:claim</td>
+      <td>_:b0</td>
       <td>http://greggkellogg.net/foaf#me</td>
       <td>xsd:type</td>
       <td>foaf:Person</td>
       <td></td>
     </tr>
     <tr>
-      <td>_:claim</td>
+      <td>_:b0</td>
       <td>http://greggkellogg.net/foaf#me</td>
       <td>foaf:name</td>
       <td>Gregg Kellogg</td>
       <td></td>
     </tr>
     <tr>
-      <td>_:claim</td>
+      <td>_:b0</td>
       <td>http://greggkellogg.net/foaf#me</td>
       <td>foaf:knows</td>
       <td>http://manu.sporny.org/about#manu</td>
@@ -2827,6 +2828,7 @@ specified. The full <a>IRI</a> for
         "@value": "2012-04-09",
         "@type": "http://www.w3.org/2001/XMLSchema#date"
       }],
+      "@id": "http://example.org/foaf-graph",
       "https://w3id.org/credentials#claim": [{****
         "@graph": [{
           "@id": "http://manu.sporny.org/about#manu",
@@ -3619,16 +3621,16 @@ specified. The full <a>IRI</a> for
         "@container": ["@graph", "@id"]
       }****
     },
-    "@id": "_:graph",
+    "@id": "http://example.org/foaf-graph",
     "generatedAt": "2012-04-09",
     ****"graphMap": {
-      "_:manu":**** {
+      "http://manu.sporny.org/about#manu":**** {
         "@id": "http://manu.sporny.org/about#manu",
         "@type": "Person",
         "name": "Manu Sporny",
         "knows": "http://greggkellogg.net/foaf#me"
       },
-      ****"_:gregg"****: {
+      ****"http://greggkellogg.net/foaf#me"****: {
         "@id": "http://greggkellogg.net/foaf#me",
         "@type": "Person",
         "name": "Gregg Kellogg",
@@ -3645,9 +3647,9 @@ specified. The full <a>IRI</a> for
        title="Referencing named graphs after expansion">
   <!--
   [{
-    "@id": "_:graph",
+    "@id": "http://example.org/foaf-graph",
     "http://example.org/graphMap": [{
-      "@id": "_:gregg",
+      "@id": "http://greggkellogg.net/foaf#me",
       "@graph": [{
         "@id": "http://greggkellogg.net/foaf#me",
         "@type": ["http://xmlns.com/foaf/0.1/Person"],
@@ -3655,7 +3657,7 @@ specified. The full <a>IRI</a> for
         "http://xmlns.com/foaf/0.1/name": [{"@value": "Gregg Kellogg"}]
       }]
     }, {
-      "@id": "_:manu",
+      "@id": "http://manu.sporny.org/about#manu",
       "@graph": [{
         "@id": "http://manu.sporny.org/about#manu",
         "@type": [
@@ -3694,62 +3696,62 @@ specified. The full <a>IRI</a> for
   <tbody>
   <tr>
     <td>&nbsp;</td>
-    <td>_:graph</td>
+    <td>http://example.org/foaf-graph</td>
     <td>prov:generatedAtTime</td>
     <td>2012-04-09</td>
     <td>xsd:date</td>
   </tr>
   <tr>
     <td>&nbsp;</td>
-    <td>_:graph</td>
+    <td>http://example.org/foaf-graph</td>
     <td>http://example.org/graphMap</td>
     <td>http://manu.sporny.org/about#manu</td>
     <td></td>
   </tr>
   <tr>
     <td>&nbsp;</td>
-    <td>_:graph</td>
+    <td>http://example.org/foaf-graph</td>
     <td>http://example.org/graphMap</td>
     <td>http://greggkellogg.net/foaf#me</td>
     <td></td>
   </tr>
   <tr>
-    <td>_:manu</td>
+    <td>http://manu.sporny.org/about#manu</td>
     <td>http://manu.sporny.org/about#manu</td>
     <td>xsd:type</td>
     <td>foaf:Person</td>
     <td></td>
   </tr>
   <tr>
-    <td>_:manu</td>
+    <td>http://manu.sporny.org/about#manu</td>
     <td>http://manu.sporny.org/about#manu</td>
     <td>foaf:name</td>
     <td>Manu Sporny</td>
     <td></td>
   </tr>
   <tr>
-    <td>_:manu</td>
+    <td>http://manu.sporny.org/about#manu</td>
     <td>http://manu.sporny.org/about#manu</td>
     <td>foaf:knows</td>
     <td>http://greggkellogg.net/foaf#me</td>
     <td></td>
   </tr>
   <tr>
-    <td>_:gregg</td>
+    <td>http://greggkellogg.net/foaf#me</td>
     <td>http://greggkellogg.net/foaf#me</td>
     <td>xsd:type</td>
     <td>foaf:Person</td>
     <td></td>
   </tr>
   <tr>
-    <td>_:gregg</td>
+    <td>http://greggkellogg.net/foaf#me</td>
     <td>http://greggkellogg.net/foaf#me</td>
     <td>foaf:name</td>
     <td>Gregg Kellogg</td>
     <td></td>
   </tr>
   <tr>
-    <td>_:gregg</td>
+    <td>http://greggkellogg.net/foaf#me</td>
     <td>http://greggkellogg.net/foaf#me</td>
     <td>foaf:knows</td>
     <td>http://manu.sporny.org/about#manu</td>
@@ -3788,7 +3790,7 @@ specified. The full <a>IRI</a> for
         "@container": ["@graph", "@id"]
       }
     },
-    "@id": "_:graph",
+    "@id": "http://example.org/foaf-graph",
     "generatedAt": "2012-04-09",
     "graphMap": {
       ****"@none"****: [{

--- a/index.html
+++ b/index.html
@@ -1586,6 +1586,38 @@ the data type to be specified with each piece of data.</p>
     any value position in the body of a JSON-LD document. Note that <a
     href="#type-coercion">type coercion</a> of the <code>knows</code> property
     is not required, as the value is not a string.</p>
+
+
+  <p>While it is considered a best practice to identify nodes in a graph,
+    at times this is impractical. In the data model, nodes without an explicit
+    identifier are called <a>blank nodes</a>, which can be represented in a
+    serialization such as JSON-LD using a <a>blank node identifier</a>. In the
+    previous example, the top-level node for Manu does not have an identifier,
+    and does not need one to describe it within the data model. However, if we
+    were to want to describe a <em>knows</em> relationship from Gregg to Manu,
+    we would need to introduce a <a>blank node identifier</a>
+    (here <code>_:b0</code>).</p>
+
+  <pre class="example nohighlight" data-transform="updateExample"
+       title="Referencing an unidentified node">
+  <!--
+  {
+    "@context": {
+      "@vocab": "http://schema.org/"
+    },
+    ****"@id": "_:b0",****
+    "name": "Manu Sporny",
+    "knows": {
+      "@id": "http://foaf.me/gkellogg#me",
+      "@type": "Person",
+      "name": "Gregg Kellogg",
+      ****"knows": {"@id": "_:b0"}****
+    }
+  }
+  -->
+  </pre>
+
+  <p><a>Blank node identifiers</a> may be automatically introduced by algorithms such as <a>flattening</a>, but they are also useful for authors to describe such relationships directly.</p>
 </section>
 
 <section class="informative">
@@ -2817,6 +2849,12 @@ specified. The full <a>IRI</a> for
     </tr>
     </tbody>
     </table>
+
+    <p class="note">The <a>blank node identifier</a> <code>_:b0</code>
+      is automatically created to allow the default graph to reference the
+      <a>named graph</a> as the definition of the <em>claim</em>. These are
+      necessary for serialization, where nodes without explicit identifiers,
+      such as the named graph in this case, can be represented.</p>
 
     <p>Expanding this graph results in the following:</p>
 


### PR DESCRIPTION
in named graph examples.

Fixes #27.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/35.html" title="Last updated on Aug 5, 2018, 7:42 PM GMT (3470dfe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/35/751cd60...3470dfe.html" title="Last updated on Aug 5, 2018, 7:42 PM GMT (3470dfe)">Diff</a>