### PR TITLE
 Update change describing the use of `@none` in maps.

### DIFF
--- a/common/common.js
+++ b/common/common.js
@@ -150,19 +150,19 @@ function internalizeTermListReferences() {
   }
 
   // delete any terms that were not referenced.
-  for (const term of Object.keys(termNames)) {
+  Object.keys(termNames).forEach(function(term) {
     const $p = $("#"+term) ;
-    if ($p && !$p.empty()) {
+    if ($p) {
       const tList = $p.getDfnTitles();
       $p.parent().next().remove();
       $p.remove() ;
-      for (const item of tList) {
+      tList.forEach(function( item ) {
         if (respecConfig.definitionMap[item]) {
-            delete respecConfig.definitionMap[item];
+          delete respecConfig.definitionMap[item];
         }
-      }
+      });
     }
-  }
+  });
 }
 
 function _esc(s) {

--- a/common/terms.html
+++ b/common/terms.html
@@ -11,11 +11,12 @@
     the JSON-LD Syntax specification [[JSON-LD11]]).</dd>
   <dt><dfn data-lt="JSON objects">JSON object</dfn></dt><dd>
     In the JSON serialization, an <a data-cite="RFC8259#section-4" class="externalDFN">object</a> structure is represented as a pair of curly brackets surrounding zero or
-    more key-value pairs. A key is a <a>string</a>. A single colon comes after
-    each key, separating the key from the value. A single comma separates a value
-    from a following key. In JSON-LD the keys in an object MUST be unique.
+    more members composed of name-value pairs. A name is a <a>string</a>. A single colon comes after
+    each name, separating the name from the value. A single comma separates a value
+    from a following name. In JSON-LD the names in an object MUST be unique.
     In the <a>internal representation</a> a <a>JSON object</a> is equivalent to a
-    <dfn data-cite="WEBIDL#dfn-dictionary" data-lt="dictionaries" class="preserve">dictionary</dfn> (see [[!WEBIDL]]).</dd>
+    <dfn data-cite="WEBIDL#dfn-dictionary" data-lt="dictionaries" class="preserve">dictionary</dfn> (see [[!WEBIDL]]),
+    composed of <dfn data-cite="WEBIDL#dfn-dictionary=members" data-lt="dictionary member|member|members">dictionary members</dfn> with key-value pairs.</dd>
   <dt class="changed"><dfn data-lt="internal representation">JSON-LD internal representation</dfn></dt><dd class="changed">The JSON-LD
     internal representation is the result of transforming a JSON syntactic structure
     into the core data structures suitable for direct processing:
@@ -23,11 +24,11 @@
     <a>strings</a>, <a>numbers</a>, <a>booleans</a>, and <a>null</a>.</dd>
   <dt><dfn>null</dfn></dt><dd>
     The use of the <a data-cite="RFC8259#section-3" class="externalDFN">null</a> value within JSON-LD is used to
-    ignore or reset values. A key-value pair in the <code>@context</code> where
+    ignore or reset values. A <a>dictionary member</a> in the <code>@context</code> where
     the value, or the <code>@id</code> of the value, is <code>null</code>
-    explicitly decouples a term's association with an IRI. A key-value pair in
+    explicitly decouples a term's association with an IRI. A <a>dictionary member</a> in
     the body of a <a>JSON-LD document</a> whose value is <code>null</code> has the
-    same meaning as if the key-value pair was not defined. If
+    same meaning as if the <a>dictionary member</a> was not defined. If
     <code>@value</code>, <code>@list</code>, or <code>@set</code> is set to
     <code>null</code> in expanded form, then the entire <a>JSON
     object</a> is ignored.</dd>
@@ -93,20 +94,20 @@
     The default language is set in the <a>context</a> using the <code>@language</code> key whose
     value MUST be a <a>string</a> representing a [[!BCP47]] language code or <code>null</code>.</dd>
   <dt><dfn>default object</dfn></dt><dd>
-    A <a>default object</a> is a <a>JSON object</a> that has a <code>@default</code> member.</dd>
+    A <a>default object</a> is a <a>dictionary</a> that has a <code>@default</code> key.</dd>
   <dt><dfn data-lt="edges">edge</dfn></dt><dd>
     Every <a>edge</a> has a direction associated with it and is labeled with
     an <a>IRI</a> or a <a>blank node identifier</a>. Within the JSON-LD syntax
     these edge labels are called <a>properties</a>. Whenever possible, an
     <a>edge</a> should be labeled with an <a>IRI</a>.</dd>
   <dt><dfn data-lt="expanded term definitions">expanded term definition</dfn></dt><dd>
-    An expanded term definition, is a <a>term definition</a> where the value is a <a>JSON object</a>
-    containing one or more <a>keyword</a> <a>properties</a> to define the associated <a>absolute IRI</a>,
+    An expanded term definition, is a <a>term definition</a> where the value is a <a>dictionary</a>
+    containing one or more <a>keyword</a> keys to define the associated <a>absolute IRI</a>,
     if this is a reverse property, the type associated with string values, and a container mapping.</dd>
   <dt><dfn data-lt="JSON-LD frame|frames">Frame</dfn></dt><dd>
     A <a>JSON-LD document</a>, which describes the form for transforming
     another <a>JSON-LD document</a> using matching and embedding rules.
-    A frame document allows additional keywords and certain property values
+    A frame document allows additional keywords and certain <a>dictionary members</a>
     to describe the matching and transforming process.</dd>
   <dt><dfn data-lt="JSON-LD Processors|Processors">JSON-LD Processor</dfn></dt><dd>
     A <a>JSON-LD Processor</a> is a system which can perform the algorithms defined in [[JSON-LD11-API]].</dd>
@@ -117,24 +118,24 @@
   <dt><dfn data-lt="graph names">graph name</dfn></dt><dd>
     The <a>IRI</a> identifying a <a data-cite="RDF11-CONCEPTS#dfn-graph-name" class="externalDFN">named graph</a>.</dd>
   <dt class="changed"><dfn data-lt="id maps">id map</dfn></dt><dd class="changed">
-    An <a>id map</a> is a <a>JSON object</a> value of a <a>term</a> defined with
+    An <a>id map</a> is a <a>dictionary</a> value of a <a>term</a> defined with
     <code>@container</code> set to <code>@id</code>, whose keys are
     interpreted as <a>IRIs</a> representing the <code>@id</code>
     of the associated <a>node object</a>; value MUST be a <a>node object</a>.
-    If the value contains a property expanding to <code>@id</code>, it's value MUST
+    If the value contains a key expanding to <code>@id</code>, it's value MUST
     be equivalent to the referencing key.</dd>
   <dt class="changed"><dfn data-lt="graph objects">graph object</dfn></dt><dd class="changed">
     A <a>graph object</a> represents a <a>named graph</a> represented as the
-    value of a <a>property</a> within a <a>node object</a>. When expanded, a
-    graph object MUST have an <code>@graph</code> member, and may also have
-    <code>@id</code>, and <code>@index</code> members.
+    value of a <a>dictionary member</a> within a <a>node object</a>. When expanded, a
+    graph object MUST have an <code>@graph</code> <a>member</a>, and may also have
+    <code>@id</code>, and <code>@index</code> <a>members</a>.
     A <dfn class="preserve" data-lt="simple graph objects">simple graph object</dfn> is a
-    <a>graph object</a> which does not have an <code>@id</code> member. Note
+    <a>graph object</a> which does not have an <code>@id</code> <a>member</a>. Note
     that <a>node objects</a> may have a <code>@graph</code> member, but are
-    not considered <a>graph objects</a> if they include any other properties.
+    not considered <a>graph objects</a> if they include any other <a>members</a>.
     A top-level object consisting of <code>@graph</code> is also not a <a>graph object</a>.</dd>
  <dt><dfn data-lt="index maps">index map</dfn></dt><dd>
-  An <a>index map</a> is a <a>JSON object</a> value of a <a>term</a> defined with
+  An <a>index map</a> is a <a>dictionary</a> value of a <a>term</a> defined with
   <code>@container</code> set to <code>@index</code>, whose values MUST be any of the following types:
     <a>string</a>,
     <a>number</a>,
@@ -158,10 +159,10 @@
     <a>true</a> or <a>false</a>, a <a>typed value</a>, or a
     <a>language-tagged string</a>.</dd>
   <dt><dfn data-lt="keywords">keyword</dfn></dt><dd>
-    A JSON key that is specific to JSON-LD, specified in the JSON-LD Syntax specification [[JSON-LD11]]
+    A <a>string</a> that is specific to JSON-LD, specified in the JSON-LD Syntax specification [[JSON-LD11]]
     in the section titled <a data-cite="JSON-LD11#syntax-tokens-and-keywords">Syntax Tokens and Keywords</a>.</dd>
   <dt><dfn data-lt="language maps">language map</dfn></dt><dd>
-    An <a>language map</a> is a <a>JSON object</a> value of a <a>term</a> defined with
+    An <a>language map</a> is a <a>dictionary</a> value of a <a>term</a> defined with
     <code>@container</code> set to <code>@language</code>, whose keys MUST be <a>strings</a> representing
     [[!BCP47]] language codes and the values MUST be any of the following types:
       <a>null</a>,
@@ -189,21 +190,23 @@
     See <dfn data-cite="RDF-SCHEMA#ch_collectionvocab" data-lt="collection" class="preserve">RDF collection</dfn>
     in [[!RDF-SCHEMA]].</dd>
   <dt><dfn data-lt="list objects">list object</dfn></dt><dd>
-    A <a>list object</a> is a <a>JSON object</a> that has an <code>@list</code>
-    member.</dd>
+    A <a>list object</a> is a <a>dictionary</a> that has a <code>@list</code>
+    key.</dd>
   <dt><dfn data-lt="literals">literal</dfn></dt><dd>
     An <a>object</a> expressed as a value such as a string, number or in expanded form.</dd>
   <dt><dfn data-lt="local contexts">local context</dfn></dt><dd>
-    A <a>context</a> that is specified within a <a>JSON object</a>,
+    A <a>context</a> that is specified with a <a>dictionary</a>,
     specified via the <code>@context</code> <a>keyword</a>.</dd>
   <dt><dfn data-lt="named graphs">named graph</dfn></dt><dd>
     A <a data-cite="RDF11-CONCEPTS#dfn-named-graph" class="externalDFN">named graph</a> is a <a>linked data graph</a> that is identified by an <a>IRI</a> or <a>blank node</a>.</dd>
   <dt><dfn data-lt="implicitly named graphs">implicitly named graph</dfn></dt><dd>
-    A <a>named graph</a> created from the value of a property having an
+    A <a>named graph</a> created from the value of a <a>dictionary member</a> having an
     <a>expanded term definition</a> where <code>@container</code> is set to  <code>@graph</code>.</dd>
   <dt><dfn data-lt="nested properties">nested property</dfn></dt><dd>
-    A <a>nested property</a> is a <a>property</a> which is contained within an object referenced by
-    a semantically meaningless <em>nesting property</em>.
+    A <a>nested property</a> is a key in a <a>node object</a> whose value is a
+    <a>dictionary</a> containing <a>members</a> which are treated as if they were values of the <a>node object</a>.
+    The <a>nested property</a> itself is semantically meaningless used only to create a sub-structure within
+    a <a>node object</a>.
   </dd>
   <dt><dfn data-lt="nodes">node</dfn></dt><dd>
     Every <a data-cite="RDF11-CONCEPTS#dfn-node" class="externalDFN">node</a> is an <a>IRI</a>, a <a>blank node</a>,
@@ -212,21 +215,22 @@
   <dt><dfn data-lt="node objects">node object</dfn></dt><dd>
     A <a>node object</a> represents zero or more <a>properties</a> of a
     <a>node</a> in the <a>graph</a> serialized by the
-    <a>JSON-LD document</a>. A <a>JSON object</a> is a <a>node object</a>
+    <a>JSON-LD document</a>. A <a>dictionary</a> is a <a>node object</a>
     if it exists outside of the JSON-LD <a>context</a> and:
     <ul>
       <li>it does not contain the <code>@value</code>, <code>@list</code>,
         or <code>@set</code> keywords, or</li>
-      <li>it is not the top-most <a>JSON object</a> in the JSON-LD document consisting
-        of no other members than <code>@graph</code> and <code>@context</code>.</li>
+      <li>it is not the top-most <a>dictionary</a> in the JSON-LD document consisting
+        of no other <a>members</a> than <code>@graph</code> and <code>@context</code>.</li>
     </ul>
+    The <a>members</a> of a <a>node object</a> whose keys are not keywords are also called <a>properties</a> of the <a>node object</a>.
   </dd>
   <dt><dfn data-lt="node references">node reference</dfn></dt><dd>
     A <a>node object</a> used to reference a node having only the
     <code>@id</code> key.</dd>
   <dt><dfn data-lt="objects">object</dfn></dt><dd>
     An <a data-cite="RDF11-CONCEPTS#dfn-object" class="externalDFN">object</a> is a <a>node</a> in a <a>linked data graph</a> with at least one incoming edge.
-    See <dfn data-cite="RDF11-CONCEPTS#dfn-object" class="preserve">RDF object</dfn>in [[RDF11-CONCEPTS]].</dd>
+    See <dfn data-cite="RDF11-CONCEPTS#dfn-object" class="preserve">RDF object</dfn> in [[RDF11-CONCEPTS]].</dd>
   <dt><dfn data-lt="prefixes">prefix</dfn></dt><dd>
     A <a>prefix</a> is the first component of a <a>compact IRI</a> which comes from a
     <a>term</a> that maps to a string that, when prepended to the suffix of the <a>compact IRI</a>
@@ -235,7 +239,7 @@
     The processing mode defines how a JSON-LD document is processed.
     By default, all documents are assumed to be conformant with
     <a data-cite="JSON-LD">JSON-LD 1.0</a> [[!JSON-LD]]. By defining
-    a different version using the <code>@version</code> member in a
+    a different version using the <code>@version</code> <a>member</a> in a
     <a>context</a>, or via explicit API option, other processing modes
     can be accessed. This specification defines extensions for the
     <code>json-ld-1.1</code> <a>processing mode</a>.</dd>
@@ -258,8 +262,7 @@
     <a>properties</a>, values of <code>@type</code>, and values of <a>terms</a> defined to be <em>vocabulary relative</em>
     are resolved relative to the <a>vocabulary mapping</a>, not the <a>base IRI</a>.</dd>
   <dt><dfn>set object</dfn></dt><dd>
-    A <a>set object</a> is a <a>JSON object</a> that has an <code>@set</code>
-    member.</dd>
+    A <a>set object</a> is a <a>dictionary</a> that has an <code>@set</code> <a>member</a>.</dd>
   <dt><dfn data-lt="subjects">subject</dfn></dt><dd>
     A <a data-cite="RDF11-CONCEPTS#dfn-subject" class="externalDFN">subject</a> is a<a>node</a> in a <a>linked data graph</a> with at least one outgoing edge, related to an <a>object</a> node through a <a>property</a>.
     See <dfn data-cite="RDF11-CONCEPTS#dfn-subject" class="preserve">RDF subject</dfn> in [[RDF11-CONCEPTS]].</dd>
@@ -268,16 +271,16 @@
   </dd>
   <dt><dfn data-lt="term definitions">term definition</dfn></dt><dd>
     A term definition is an entry in a <a>context</a>, where the key defines a <a>term</a> which may be used within
-    a <a>JSON object</a> as a <a>property</a>, type, or elsewhere that a string is interpreted as a vocabulary item.
+    a <a>dictionary</a> as a key, type, or elsewhere that a string is interpreted as a vocabulary item.
     Its value is either a string (<dfn data-lt="simple terms|simple term|simple term definitions">simple term definition</dfn>), expanding to an absolute IRI, or an <a>expanded term definition</a>.
   </dd>
   <dt class="changed"><dfn data-lt="type maps">type map</dfn></dt><dd class="changed">
-    An <a>type map</a> is a <a>JSON object</a> value of a <a>term</a> defined with
+    An <a>type map</a> is a <a>dictionary</a> value of a <a>term</a> defined with
     <code>@container</code> set to <code>@type</code>, whose keys are
     interpreted as <a>IRIs</a> representing the <code>@type</code>
     of the associated <a>node object</a>;
     value MUST be a <a>node object</a>, or <a>array</a> of node objects.
-    If the value contains a property expanding to <code>@type</code>, it's values
+    If the value contains a <a>term</a> expanding to <code>@type</code>, it's values
     are merged with the map value when expanding.</dd>
   <dt><dfn>typed literal</dfn></dt><dd>
     A <a data-cite="RDF11-CONCEPTS#dfn-typed-literal" class="externalDFN">typed literal</a> is a <a>literal</a> with an associated <a>IRI</a>
@@ -287,9 +290,8 @@
     A <a>typed value</a> consists of a value, which is a <a>string</a>, and a type,
     which is an <a>IRI</a>.</dd>
   <dt><dfn data-lt="value objects">value object</dfn></dt><dd>
-    A <a>value object</a> is a <a>JSON object</a> that has an <code>@value</code>
-    member.</dd>
+    A <a>value object</a> is a <a>dictionary</a> that has an <code>@value</code> <a>member</a>.</dd>
   <dt><dfn>vocabulary mapping</dfn></dt><dd>
     The vocabulary mapping is set in the <a>context</a> using the <code>@vocab</code> key whose
-    value MUST be an <a>absolute IRI</a> <code>null</code>.</dd>
+    value MUST be an <a>absolute IRI</a> or <code>null</code>.</dd>
 </dl>

--- a/index.html
+++ b/index.html
@@ -5755,9 +5755,9 @@ the data type to be specified with each piece of data.</p>
       to allow for other serializations that are functionally equivalent
       to JSON.</li>
     <li>Added <a href="#node-identifier-indexing" class="sectionRef"></a> and <a href="#node-type-indexing" class="sectionRef"></a>.</li>
-    <li>Both <a>language maps</a> and <a>index maps</a> may legitimately have an <code>@none</code> value, but
-      JSON-LD 1.0 only allowed <a>string</a> values. This has been updated
-      to allow (and ignore) <code>@null</code> values.</li>
+    <li>Both <a>language maps</a> and <a>index maps</a> may legitimately have an <code>@none</code> name, but
+      JSON-LD 1.0 only allowed <a>string</a> names. This has been updated
+      to allow <code>@none</code> names.</li>
     <li>The value for <code>@container</code> in an <a>expanded term definition</a>
       can also be an <a>array</a> containing any appropriate container
       keyword along with <code>@set</code> (other than <code>@list</code>).
@@ -6229,7 +6229,6 @@ the data type to be specified with each piece of data.</p>
   <p class="issue defer" data-number="18"></p>
   <p class="issue defer" data-number="19"></p>
   <p class="issue defer" data-number="20"></p>
-  <p class="issue defer" data-number="22"></p>
   <p class="issue defer" data-number="23"></p>
   <p class="issue defer" data-number="25"></p>
   <p class="issue defer" data-number="26"></p>
@@ -6241,7 +6240,6 @@ the data type to be specified with each piece of data.</p>
   <p class="issue defer" data-number="38"></p>
   <p class="issue defer" data-number="46"></p>
   <p class="issue defer" data-number="48"></p>
-  <p class="issue defer" data-number="55"></p>
   <p class="issue defer" data-number="56"></p>
   <p class="issue defer" data-number="57"></p>
 </section>

--- a/index.html
+++ b/index.html
@@ -197,7 +197,7 @@
     <li>a way to disambiguate keys shared among different JSON documents by mapping
       them to <a>IRIs</a> via a <a>context</a>,</li>
     <li>a mechanism in which a value in a <a>JSON object</a> may refer
-      to a <a>JSON object</a> on a different site on the Web,</li>
+      to a <a>resource</a> on a different site on the Web,</li>
     <li>the ability to annotate <a>strings</a> with their language,</li>
     <li>a way to associate datatypes with values such as dates and times,</li>
     <li>and a facility to express one or more directed graphs, such as a social
@@ -639,9 +639,9 @@
 
     <p>As the <a>context</a> above shows, the value of a <a>term definition</a> can
       either be a simple string, mapping the <a>term</a> to an <a>IRI</a>,
-      or a <a>JSON object</a>.</p>
+      or a <a>dictionary</a>.</p>
 
-    <p>When a <a>JSON object</a> is associated with a term, it is called
+    <p>When a when a <a>member</a> with a <a>term</a> key has a <a>dictionary</a> value, the <a>dictionary</a> is called
       an <a>expanded term definition</a>. The example above specifies that
       the values of <code>image</code> and <code>homepage</code>, if they are
       strings, are to be interpreted as
@@ -750,7 +750,7 @@
     <a>vocabulary mapping</a>, and not the <a>base IRI</a>.</p>
 
   <p>A <a>string</a> is interpreted as an <a>IRI</a> when it is the
-    value of an <code>@id</code> member:</p>
+    value of an <a>dictionary member</a> with the key<code>@id</code>:</p>
 
   <pre class="example nohighlight" data-transform="updateExample"
        title="Values of @id are interpreted as IRI">
@@ -850,7 +850,7 @@
     different ways in JSON-LD:</p>
 
   <ol>
-    <li><a>JSON object</a> keys that have a <a>term</a> mapping in
+    <li><a>Dictionary members</a> that have a key mapping to a <a>term</a> in
       the <a>active context</a> expand to an <a>IRI</a>
       (only applies outside of the <a>context definition</a>).</li>
     <li>An <a>IRI</a> is generated for the <a>string</a> value specified using
@@ -1092,7 +1092,7 @@
   be achieved using JSON-LD.</p>
 
   <p>In general, contexts may be used any time a
-    <a>JSON object</a> is defined.
+    <a>dictionary</a> is defined.
     The only time that one cannot express a context is as a direct child of another context definition (other than as part of an <a>expanded term definition</a>).
     For example, a <a>JSON-LD document</a> may use more than one context at different
     points in a document:</p>
@@ -1147,14 +1147,14 @@
     in the more deeply nested <code>details</code> structure. Note that this is
     rarely a good authoring practice and is typically used when working with
     legacy applications that depend on a specific structure of the
-    <a>JSON object</a>. If a <a>term</a> is redefined within a
+    <a>dictionary</a>. If a <a>term</a> is redefined within a
     context, all previous rules associated with the previous definition are
     removed. If a <a>term</a> is redefined to <code>null</code>,
     the <a>term</a> is effectively removed from the list of
     <a>terms</a> defined in the <a>active context</a>.</p>
 
   <p>Multiple contexts may be combined using an <a>array</a>, which is processed
-    in order. The set of contexts defined within a specific <a>JSON object</a> are
+    in order. The set of contexts defined within a specific <a>dictionary</a> are
     referred to as <a>local contexts</a>. The
     <a>active context</a> refers to the accumulation of
     <a>local contexts</a> that are in scope at a
@@ -1200,7 +1200,7 @@
 
   <p>New features defined in JSON-LD 1.1 are available
     when the <a>processing mode</a> is set to <code>json-ld-1.1</code>.
-    This may be set using the <code>@version</code> member in a <code>context</code>
+    This may be set using the <code>@version</code> <a>member</a> in a <code>context</code>
     set to the value <code>1.1</code> as a <a>number</a>, or through an API option.</p>
 
   <pre class="example nohighlight" data-transform="updateExample"
@@ -1251,10 +1251,10 @@
   </pre>
 
   <p>If <code>@vocab</code> is used but certain keys in an
-    <a data-lt="JSON object">object</a> should not be expanded using
+    <a>dictionary</a> should not be expanded using
     the vocabulary <a>IRI</a>, a <a>term</a> can be explicitly set
     to <a>null</a> in the <a>context</a>. For instance, in the
-    example below the <code>databaseId</code> member would not expand to an
+    example below the <code>databaseId</code> <a>member</a> would not expand to an
     <a>IRI</a> causing the property to be dropped when expanding.</p>
 
   <pre class="example nohighlight" data-transform="updateExample"
@@ -1446,7 +1446,7 @@
     when compacting only if
     a <a>simple term definition</a> is used where the value ends with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
     or if their <a>expanded term definition</a> contains
-    a <code>@prefix</code> member with the value <a>true</a>.</p>
+    a <code>@prefix</code> <a>member</a> with the value <a>true</a>.</p>
 
   <p class="note">This represents a small change to the 1.0 algorithm to prevent IRIs
     that are not really intended to be used as prefixes from being used for creating
@@ -1454,7 +1454,7 @@
 
   <p class="changed">When <a>processing mode</a> is set to <code>json-ld-1.1</code>, terms will be used as <a>compact IRI</a> prefixes
     when compacting only if their <a>expanded term definition</a> contains
-    a <code>@prefix</code> member with the value <a>true</a>, or if it has a
+    a <code>@prefix</code> <a>member</a> with the value <a>true</a>, or if it has a
     a <a>simple term definition</a>  where the value ends with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character
     (e.g, <code>/</code>, <code>#</code> and others, see [[!RFC3986]]).</p>
 
@@ -1925,7 +1925,7 @@ in the body of a JSON-LD document:</p>
   (<code>http://www.w3.org/2001/XMLSchema#dateTime</code>) with the
   value expressed using the <code>@value</code> <a>keyword</a>. As a
   general rule, when <code>@value</code> and <code>@type</code> are used in
-  the same <a>JSON object</a>, the <code>@type</code>
+  the same <a>dictionary</a>, the <code>@type</code>
   <a>keyword</a> is expressing a <a>value type</a>.
   Otherwise, the <code>@type</code> <a>keyword</a> is expressing a
   <a>node type</a>. The example above expresses the following data:</p>
@@ -3720,8 +3720,8 @@ the data type to be specified with each piece of data.</p>
   </table>
 
   <p>When a JSON-LD document's top-level structure is an
-    <a data-lt="JSON object">object</a> that contains no other
-    <a>properties</a> than <code>@graph</code> and
+    <a>dictionary</a> that contains no other
+    keys than <code>@graph</code> and
     optionally <code>@context</code> (properties that are not mapped to an
     <a>IRI</a> or a <a>keyword</a> are ignored),
     <code>@graph</code> is considered to express the otherwise implicit
@@ -4572,7 +4572,7 @@ the data type to be specified with each piece of data.</p>
   <p>The JSON-LD 1.1 Processing Algorithms and API specification [[JSON-LD11-API]] defines
     a method for <em>flattening</em> a JSON-LD document.
     <dfn data-cite="JSON-LD11-API#dfn-flattening" data-lt="flattened">Flattening</dfn> collects all
-    properties of a <a>node</a> in a single <a>JSON object</a> and labels
+    properties of a <a>node</a> in a single <a>dictionary</a> and labels
     all <a>blank nodes</a> with
     <a>blank node identifiers</a>.
     This ensures a shape of the data and consequently may drastically simplify the code
@@ -4756,7 +4756,7 @@ the data type to be specified with each piece of data.</p>
   </ul>
 
   <p>The referenced document MUST have a top-level <a>JSON object</a>.
-    The <code>@context</code> subtree within that object is added to the top-level
+    The <code>@context</code> <a>member</a> within that object is added to the top-level
     <a>JSON object</a> of the referencing document. If an <a>array</a>
     is at the top-level of the referencing document and its items are
     <a>JSON objects</a>, the <code>@context</code>
@@ -4977,8 +4977,8 @@ the data type to be specified with each piece of data.</p>
       valid <a data-cite="RFC8259#section-2">JSON text</a></span>.</p>
 
   <p>A <a>JSON-LD document</a> MUST be a single <a>node object</a>,
-    a <a>JSON object</a> consisting of only
-    the members <code>@context</code> and/or <code>@graph</code>,
+    a <a>dictionary</a> consisting of only
+    the <a>members</a> <code>@context</code> and/or <code>@graph</code>,
     or an <a>array</a> or zero or more <a>node objects</a>.</p>
 
   <p>In contrast to JSON, in JSON-LD the keys in <a data-lt="JSON object">objects</a>
@@ -5027,13 +5027,13 @@ the data type to be specified with each piece of data.</p>
 
     <p>A <a>node object</a> represents zero or more properties of a
       <a>node</a> in the <a>graph</a> serialized by the
-      <a>JSON-LD document</a>. A <a>JSON object</a> is a
+      <a>JSON-LD document</a>. A <a>dictionary</a> is a
       <a>node object</a> if it exists outside of a JSON-LD
       <a>context</a> and:</p>
 
     <ul>
-      <li>it is not the top-most <a>JSON object</a> in the JSON-LD document consisting
-        of no other members than <code>@graph</code> and <code>@context</code>,</li>
+      <li>it is not the top-most <a>dictionary</a> in the JSON-LD document consisting
+        of no other <a>members</a> than <code>@graph</code> and <code>@context</code>,</li>
       <li>it does not contain the <code>@value</code>, <code>@list</code>,
         or <code>@set</code> keywords, and</li>
       <li class="changed">it is not a <a>graph object</a>.</li>
@@ -5046,7 +5046,7 @@ the data type to be specified with each piece of data.</p>
       <a>node objects</a> need to be merged to create the
       properties of the resulting <a>node</a>.</p>
 
-    <p>A <a>node object</a> MUST be a <a>JSON object</a>. All keys
+    <p>A <a>node object</a> MUST be a <a>dictionary</a>. All keys
       which are not <a>IRIs</a>, <a>compact IRIs</a>, <a>terms</a> valid in the
       <a>active context</a>, or one of the following <a>keywords</a>
       <span class="changed">(or alias of such a keyword)</span>
@@ -5083,10 +5083,10 @@ the data type to be specified with each piece of data.</p>
       If the <a>node object</a> contains an <code>@id</code> keyword,
       its value is used as the <a>graph name</a> of a <a>named graph</a>.
       See <a class="sectionRef" href="#named-graphs"></a> for further discussion on
-      <code>@graph</code> values. As a special case, if a <a>JSON object</a>
+      <code>@graph</code> values. As a special case, if a <a>dictionary</a>
       contains no keys other than <code>@graph</code> and <code>@context</code>, and the
-      <a>JSON object</a> is the root of the JSON-LD document, the
-      <a>JSON object</a> is not treated as a <a>node object</a>; this
+      <a>dictionary</a> is the root of the JSON-LD document, the
+      <a>dictionary</a> is not treated as a <a>node object</a>; this
       is used as a way of defining <a>node objects</a>
       that may not form a connected graph. This allows a
       <a>context</a> to be defined which is shared by all of the constituent
@@ -5102,7 +5102,7 @@ the data type to be specified with each piece of data.</p>
       <code>@type</code> values.</p>
 
     <p>If the <a>node object</a> contains the <code>@reverse</code> key,
-      its value MUST be a <a>JSON object</a> containing members representing reverse
+      its value MUST be a <a>dictionary</a> containing <a>members</a> representing reverse
       properties. Each value of such a reverse property MUST be an <a>absolute IRI</a>,
       a <a>relative IRI</a>, a <a>compact IRI</a>, a <a>blank node identifier</a>,
       a <a>node object</a> or an <a>array</a> containing a combination of these.</p>
@@ -5113,7 +5113,7 @@ the data type to be specified with each piece of data.</p>
       on <code>@index</code> values.</p>
 
     <p class="changed">If the <a>node object</a> contains the <code>@nest</code> key,
-      its value MUST be an <a>JSON object</a> or an <a>array</a> of <a>JSON objects</a>
+      its value MUST be an <a>dictionary</a> or an <a>array</a> of <a>dictionaries</a>
       which MUST NOT include a <a>value object</a>. See
       <a class="sectionRef" href="#property-nesting"></a> for further discussion
       on <code>@nest</code> values.</p>
@@ -5147,11 +5147,11 @@ the data type to be specified with each piece of data.</p>
 
     <p>A <a>graph object</a> represents a <a>named graph</a>, which MAY include
       include an explicit <a>graph name</a>.
-      A <a>JSON object</a> is a <a>graph object</a> if
+      A <a>dictionary</a> is a <a>graph object</a> if
       it exists outside of a JSON-LD <a>context</a>,
       it is not a <a>node object</a>,
-      it is not the top-most <a>JSON object</a> in the JSON-LD document, and
-      it consists of no members other than <code>@graph</code>,
+      it is not the top-most <a>dictionary</a> in the JSON-LD document, and
+      it consists of no <a>members</a> other than <code>@graph</code>,
       <code>@index</code>, <code>@id</code>
       and <code>@context</code>, or an alias of one of these <a>keywords</a>.</p>
 
@@ -5170,7 +5170,7 @@ the data type to be specified with each piece of data.</p>
       <a class="sectionRef" href="#identifying-blank-nodes"></a> for further discussion on
       <code>@id</code> values.</p>
 
-    <p>A <a>graph object</a> without an <code>@id</code> member is also a
+    <p>A <a>graph object</a> without an <code>@id</code> <a>member</a> is also a
       <a>simple graph object</a> and represents a <a>named graph</a> without an
       explicit identifier, although in the data model it still has a
       <a>graph name</a>, which is an implicitly allocated
@@ -5190,7 +5190,7 @@ the data type to be specified with each piece of data.</p>
       language with a value to create a <a>typed value</a> or a <a>language-tagged
       string</a>.</p>
 
-    <p>A <a>value object</a> MUST be a <a>JSON object</a> containing the
+    <p>A <a>value object</a> MUST be a <a>dictionary</a> containing the
       <code>@value</code> key. It MAY also contain an <code>@type</code>,
       an <code>@language</code>, an <code>@index</code>, or an <code>@context</code> key but MUST NOT contain
       both an <code>@type</code> and an <code>@language</code> key at the same time.
@@ -5233,11 +5233,11 @@ the data type to be specified with each piece of data.</p>
       This simplifies post-processing of the data as the data is always in a
       deterministic form.</p>
 
-    <p>A <a>list object</a> MUST be a <a>JSON object</a> that contains no
+    <p>A <a>list object</a> MUST be a <a>dictionary</a> that contains no
       keys that expand to an <a>absolute IRI</a> or <a>keyword</a> other
       than <code>@list</code>, <code>@context</code>, and <code>@index</code>.</p>
 
-    <p>A <a>set object</a> MUST be a <a>JSON object</a> that contains no
+    <p>A <a>set object</a> MUST be a <a>dictionary</a> that contains no
       keys that expand to an <a>absolute IRI</a> or <a>keyword</a> other
       than <code>@set</code>, <code>@context</code>, and <code>@index</code>.
       Please note that the <code>@index</code> key will be ignored when being processed.</p>
@@ -5294,7 +5294,7 @@ the data type to be specified with each piece of data.</p>
       <span class="changed">
         or an array containing both <code>@index</code> and <code>@set</code>
       </span>.
-      The values of the members of an <a>index map</a> MUST be one
+      The values of the <a>members</a> of an <a>index map</a> MUST be one
       of the following types:</p>
 
     <ul>
@@ -5369,7 +5369,7 @@ the data type to be specified with each piece of data.</p>
     <h2>Property Nesting</h2>
 
     <p>A <a>nested property</a> is used to gather <a>properties</a> of a <a>node object</a> in a separate
-      <a>JSON object</a>, or <a>array</a> of <a>JSON objects</a> which are not
+      <a>dictionary</a>, or <a>array</a> of <a>dictionaries</a> which are not
       <a>value objects</a>. It is semantically transparent and is removed
       during the process of <a>expansion</a>. Property nesting is recursive, and
       collections of nested properties may contain further nesting.</p>
@@ -5384,7 +5384,7 @@ the data type to be specified with each piece of data.</p>
   <p>A <dfn>context definition</dfn> defines a <a>local context</a> in a
     <a>node object</a>.</p>
 
-  <p>A <a>context definition</a> MUST be a <a>JSON object</a> whose
+  <p>A <a>context definition</a> MUST be a <a>dictionary</a> whose
     keys MUST be either <a>terms</a>, <a>compact IRIs</a>, <a>absolute IRIs</a>,
     or one of the <a>keywords</a> <code>@language</code>, <code>@base</code>,
     <code>@vocab</code>, or <code class="changed">@version</code>.</p>
@@ -5415,7 +5415,7 @@ the data type to be specified with each piece of data.</p>
     properties of the value associated with the <a>term</a> when it is
     used as key in a <a>node object</a>.</p>
 
-  <p>An <a>expanded term definition</a> MUST be a <a>JSON object</a>
+  <p>An <a>expanded term definition</a> MUST be a <a>dictionary</a>
     composed of zero or more keys from
     <code>@id</code>,
     <code>@reverse</code>,
@@ -5436,11 +5436,11 @@ the data type to be specified with each piece of data.</p>
     a <a>blank node identifier</a>, a <a>compact IRI</a>, a <a>term</a>,
     or a <a>keyword</a>.</p>
 
-  <p>If an <a>expanded term definition</a> has an <code>@reverse</code> member,
-    it MUST NOT have <code>@id</code> or <code>@nest</code> members at the same time,
+  <p>If an <a>expanded term definition</a> has an <code>@reverse</code> <a>member</a>,
+    it MUST NOT have <code>@id</code> or <code>@nest</code> <a>members</a> at the same time,
     its value MUST be an <a>absolute IRI</a>,
     a <a>blank node identifier</a>, a <a>compact IRI</a>, or a <a>term</a>. If an
-    <code>@container</code> member exists, its value MUST be <a>null</a>,
+    <code>@container</code> <a>member</a> exists, its value MUST be <a>null</a>,
     <code>@set</code>, or <code>@index</code>.</p>
 
   <p>If the <a>expanded term definition</a> contains the <code>@type</code>
@@ -5477,7 +5477,7 @@ the data type to be specified with each piece of data.</p>
     the <code>@context</code>, the associated value MUST be an
     <a>index map</a>.</p>
 
-  <p class="changed">If an <a>expanded term definition</a> has an <code>@context</code> member,
+  <p class="changed">If an <a>expanded term definition</a> has an <code>@context</code> <a>member</a>,
     it MUST be a valid <code>context definition</code>.</p>
 
   <p class="changed">If the <a>expanded term definition</a> contains the <code>@nest</code>
@@ -5739,7 +5739,7 @@ the data type to be specified with each piece of data.</p>
 <section class="appendix informative">
   <h2>Changes since 1.0 Recommendation of 16 January 2014</h2>
   <ul>
-    <li>A context may contain a <code>@version</code> member which is used to set the <a>processing mode</a>.</li>
+    <li>A context may contain a <code>@version</code> <a>member</a> which is used to set the <a>processing mode</a>.</li>
     <li>An <a>expanded term definition</a> can now have an
       <code>@context</code> property, which defines a <a>context</a> used for values of
       a <a>property</a> identified with such a <a>term</a>.</li>
@@ -5755,9 +5755,9 @@ the data type to be specified with each piece of data.</p>
       to allow for other serializations that are functionally equivalent
       to JSON.</li>
     <li>Added <a href="#node-identifier-indexing" class="sectionRef"></a> and <a href="#node-type-indexing" class="sectionRef"></a>.</li>
-    <li>Both <a>language maps</a> and <a>index maps</a> may legitimately have an <code>@none</code> name, but
-      JSON-LD 1.0 only allowed <a>string</a> names. This has been updated
-      to allow <code>@none</code> names.</li>
+    <li>Both <a>language maps</a> and <a>index maps</a> may legitimately have an <code>@none</code> key, but
+      JSON-LD 1.0 only allowed <a>string</a> keys. This has been updated
+      to allow <code>@none</code> keys.</li>
     <li>The value for <code>@container</code> in an <a>expanded term definition</a>
       can also be an <a>array</a> containing any appropriate container
       keyword along with <code>@set</code> (other than <code>@list</code>).
@@ -5767,7 +5767,7 @@ the data type to be specified with each piece of data.</p>
       when compacting only if
       a <a>simple term definition</a> is used where the value ends with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
       or if their <a>expanded term definition</a> contains
-      a <code>@prefix</code> member with the value <a>true</a>. The 1.0 algorithm has
+      a <code>@prefix</code> <a>member</a> with the value <a>true</a>. The 1.0 algorithm has
       been updated to only consider terms that map to a value that ends with a URI
       <a data-cite="RFC3986#section-2.2">gen-delim</a> character.</li>
     <li>Values of properties where the associated <a>term definition</a>
@@ -5782,7 +5782,7 @@ the data type to be specified with each piece of data.</p>
       a context. When this is set, vocabulary-relative IRIs, such as the
       keys of <a>node objects</a>, are expanded or compacted relative
       to the <a>base IRI</a> using string concatenation.</li>
-    <li><a>Lists</a> may now have members which are themselves <a>lists</a>.</li>
+    <li><a>Lists</a> may now have items which are themselves <a>lists</a>.</li>
   </ul>
 </section>
 


### PR DESCRIPTION
Also generally improve terminology to be more consistent throughout the document.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/62.html" title="Last updated on Aug 27, 2018, 11:59 PM GMT (772d070)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/62/1d528bb...772d070.html" title="Last updated on Aug 27, 2018, 11:59 PM GMT (772d070)">Diff</a>