### PR TITLE
Improve keyword descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -494,13 +494,13 @@
       <dd>Used to set the type of a <a>node</a> or the datatype of a <a>typed value</a>.
         This keyword is described further in <a class="sectionRef" href="#specifying-the-type"></a>
         and <a class="sectionRef" href="#typed-values"></a>.
-        <div class="note">The notion of type can be confusing, as both
-          nodes and literal values can have types,
-          but in the <a>data model</a>,
-          these are fundamentally different things.
-          The use of <code>@type</code> to define a type for both <a>node objects</a> and <a>value objects</a>
-          addresses the basic need to type data,
-          be it a literal value or a more complicated <a>resource</a>.
+        <div class="note">The use of <code>@type</code> to define a type for both
+          <a>node objects</a> and <a>value objects</a> addresses the basic need to type data,
+          be it a literal value or a more complicated resource.
+          Experts may find the overloaded use of the <code>@type</code> keyword for both purposes concerning,
+          but should note that Web developer usage of this feature over multiple years
+          has not resulted in its misuse due to the far less frequent use of <code>@type</code>
+          to express typed literal values.
         </div>
       </dd>
       <dt><code>@container</code></dt>
@@ -1453,7 +1453,7 @@
     <li><a>JSON objects</a>, which provide a set of <a>dictionary members</a>, relating keys with values.</li>
   </ul>
 
-  <p>The JSON-LD data model allows for a richer set of resources, based on the RDF data mode.
+  <p>The JSON-LD data model allows for a richer set of resources, based on the RDF data model.
     The data model is described more fully in <a class="sectionRef" href="#data-model"></a>.
     JSON-LD uses JSON objects to describe various resources, along with the relationships
     between these resources:</p>
@@ -3114,7 +3114,7 @@ type with a particular <a>term</a> in the <code>@context</code>:</p>
   </pre>
 </aside>
 
-<p>The <em>modified</em> key's value above is automatically type interpreted as a
+<p>The <em>modified</em> key's value above is automatically interpreted as a
   <em>dateTime</em> value because of the information specified in the
   <code>@context</code>. The example tabs show how a <a>JSON-LD processor</a> will interpret the data.</p>
 
@@ -9643,24 +9643,24 @@ the data type to be specified explicitly with each piece of data.</p>
     <dt><code>@container</code></dt><dd>
       The <code>@container</code> keyword MUST NOT be aliased, and MAY be used as a key in an <a>expanded term definition</a>.
       Its value MUST be either
-          <code>@list</code>,
-          <code>@set</code>,
-          <code>@language</code>,
-          <code>@index</code>,
-          <span><code>@id</code></span>,
-          <span><code>@graph</code></span>,
-          <span><code>@type</code></span>, or be
-          <a>null</a>,
-          or an <a>array</a> containing exactly any one of those keywords, or a
-          combination of <code>@set</code> and any of <code>@index</code>,
-          <code>@id</code>, <code>@graph</code>, <code>@type</code>,
-          <code>@language</code> in any order.
-          The value may also be an array
-          containing <code>@graph</code> along with either <code>@id</code> or
-          <code>@index</code> and also optionally including <code>@set</code>.</span>
+      <code>@list</code>,
+      <code>@set</code>,
+      <code>@language</code>,
+      <code>@index</code>,
+      <span><code>@id</code></span>,
+      <span><code>@graph</code></span>,
+      <span><code>@type</code></span>, or be
+      <a>null</a>,
+      or an <a>array</a> containing exactly any one of those keywords, or a
+      combination of <code>@set</code> and any of <code>@index</code>,
+      <code>@id</code>, <code>@graph</code>, <code>@type</code>,
+      <code>@language</code> in any order.
+      The value may also be an array
+      containing <code>@graph</code> along with either <code>@id</code> or
+      <code>@index</code> and also optionally including <code>@set</code>.
     </dd>
     <dt><code>@context</code></dt><dd>
-      The <code>@context</code> keyword MUST NOT be aliased, and MAY be used as a key in the following objects:</p>
+      The <code>@context</code> keyword MUST NOT be aliased, and MAY be used as a key in the following objects:
       <ul data-sort>
         <li><a>node objects</a> (see <a class="sectionRef" href="#node-objects"></a>),</li>
         <li><a>value objects</a> (see <a class="sectionRef" href="#value-objects"></a>),</li>

--- a/index.html
+++ b/index.html
@@ -542,7 +542,7 @@
       <dt class="changed"><code>@nest</code></dt><dd class="changed">Collects a set of <a>nested properties</a> within
         a <a>node object</a>.</dd>
       <dt class="changed"><code>@none</code></dt><dd class="changed">Used as an index value
-        in an <a>id map</a>, <a>language map</a>, <a>type map</a>, or elsewhere where a dictionary is
+        in an <a>index map</a>, <a>id map</a>, <a>language map</a>, <a>type map</a>, or elsewhere where a dictionary is
         used to index into other values.</dd>
       <dt class="changed"><code>@prefix</code></dt><dd class="changed">
         With the value <a>true</a>, allows this <a>term</a> to be used to construct a <a>compact IRI</a>
@@ -2668,7 +2668,7 @@
   <p>Since keywords cannot be redefined, they can also not be aliased to
     other keywords.</p>
 
-  <p class="note">Aliased keywords may not be used within a <a>context</a>, itself.</p>
+  <p class="note">Aliased keywords MUST NOT be used within a <a>context</a>, itself.</p>
 </section>
 
 <section class="informative"><h2>IRI Expansion within a Context</h2>
@@ -3114,7 +3114,7 @@ type with a particular <a>term</a> in the <code>@context</code>:</p>
   </pre>
 </aside>
 
-<p>The <em>modified</em> key's value above is automatically type coerced to a
+<p>The <em>modified</em> key's value above is automatically type interpreted as a
   <em>dateTime</em> value because of the information specified in the
   <code>@context</code>. The example tabs show how a <a>JSON-LD processor</a> will interpret the data.</p>
 
@@ -3191,7 +3191,8 @@ in the body of a JSON-LD document:</p>
 
 <p class="note">The <code>@type</code> <a>keyword</a> is also used to associate a type
   with a <a>node</a>. The concept of a <a>node type</a> and
-  a <a>value type</a> are different.</p>
+  a <a>value type</a> are different.
+  For more on adding types to <a>nodes</a>, see <a class="sectionRef" href="#specifying-the-type"></a>.</p>
 
 <p>A <dfn>node type</dfn> specifies the type of thing
   that is being described, like a person, place, event, or web page. A
@@ -9629,6 +9630,175 @@ the data type to be specified explicitly with each piece of data.</p>
   <p>See <a class="sectionRef" href="#the-context"></a> for further discussion on contexts.</p>
 </section>
 
+<section class="normative changed">
+  <h2>Keywords</h2>
+  <p>JSON-LD <a>keywords</a> are described in <a class="sectionRef" href="#syntax-tokens-and-keywords"></a>,
+    this section describes where each <a>keyword</a> may appear within different JSON-LD structures.</p>
+
+  <dl data-sort>
+    <dt><code>@base</code></dt><dd>
+      The <code>@base</code> keyword MUST NOT be aliased, and MAY be used as a key in a <a>context definition</a>.
+      Its value MUST be an <a>absolute IRI</a>, a <a>relative IRI</a>, or <a>null</a>.
+    </dd>
+    <dt><code>@container</code></dt><dd>
+      The <code>@container</code> keyword MUST NOT be aliased, and MAY be used as a key in an <a>expanded term definition</a>.
+      Its value MUST be either
+          <code>@list</code>,
+          <code>@set</code>,
+          <code>@language</code>,
+          <code>@index</code>,
+          <span><code>@id</code></span>,
+          <span><code>@graph</code></span>,
+          <span><code>@type</code></span>, or be
+          <a>null</a>,
+          or an <a>array</a> containing exactly any one of those keywords, or a
+          combination of <code>@set</code> and any of <code>@index</code>,
+          <code>@id</code>, <code>@graph</code>, <code>@type</code>,
+          <code>@language</code> in any order.
+          The value may also be an array
+          containing <code>@graph</code> along with either <code>@id</code> or
+          <code>@index</code> and also optionally including <code>@set</code>.</span>
+    </dd>
+    <dt><code>@context</code></dt><dd>
+      The <code>@context</code> keyword MUST NOT be aliased, and MAY be used as a key in the following objects:</p>
+      <ul data-sort>
+        <li><a>node objects</a> (see <a class="sectionRef" href="#node-objects"></a>),</li>
+        <li><a>value objects</a> (see <a class="sectionRef" href="#value-objects"></a>),</li>
+        <li><a>graph objects</a> (see <a class="sectionRef" href="#graph-objects"></a>),</li>
+        <li><a>list objects</a> (see <a class="sectionRef" href="#lists-and-sets"></a>),</li>
+        <li><a>set objects</a> (see <a class="sectionRef" href="#lists-and-sets"></a>),</li>
+        <li><a>nested properties</a> (see <a class="sectionRef" href="#property-nesting"></a>), and</li>
+        <li><a>expanded term definitions</a> (see <a class="sectionRef" href="#context-definitions"></a>).</li>
+      </ul>
+      The value of <code>@context</code> MUST be
+      <a>null</a>,
+      an <a>absolute IRI</a>,
+      a <a>relative IRI</a>,
+      a <a>context definition</a>, or
+      an <a>array</a> composed of any of these.
+    </dd>
+    <dt><code>@id</code></dt><dd>
+      The <code>@id</code> keyword MAY be aliased and MAY be used as a key in a <a>node object</a> or a <a>graph object</a>.
+      The unaliased <code>@id</code> MAY be used as a key in an <a>expanded term definition</a>,
+      or as the value of the <code>@container</code> key within an <a>expanded term definition</a>.
+      The value of the <code>@id</code> key MUST  be an <a>absolute IRI</a>, a <a>relative IRI</a>,
+      or a <a>compact IRI</a> (including <a>blank node identifiers</a>).
+      See <a class="sectionRef" href="#node-identifiers"></a>,
+      <a class="sectionRef" href="#compact-iris"></a>, and
+      <a class="sectionRef" href="#identifying-blank-nodes"></a> for further discussion on
+      <code>@id</code> values.
+    </dd>
+    <dt><code>@index</code></dt><dd>
+      The <code>@index</code> keyword MAY be aliased and MAY be used as a key in a
+      <a>node object</a>, <a>value object</a>, <a>graph object</a>, <a>set object</a>, or <a>list object</a>.
+      The unaliased <code>@index</code> MAY be used as the value of the <code>@container</code> key within an <a>expanded term definition</a>.
+      Its value MUST be a <a>string</a>.
+      See <a class="sectionRef" href="#index-maps"></a> for a further discussion.
+    </dd>
+    <dt><code>@language</code></dt><dd>
+      The <code>@language</code> keyword MAY be aliased and MAY be used as a key in a <a>value object</a>.
+      The unaliased <code>@language</code> MAY be used as a key in a <a>context definition</a>,
+      or as the value of the <code>@container</code> key within an <a>expanded term definition</a>.
+      Its value MUST be a <a>string</a> with the <a data-cite="BCP47#section-2.1.1">lexical form</a> described in [[BCP47]] or be <a>null</a>..
+      See <a class="sectionRef" href="#index-maps"></a> for a further discussion.
+    </dd>
+    <dt><code>@list</code></dt><dd>
+      The <code>@list</code> keyword MAY be aliased and MUST be used as a key in a <a>list object</a>.
+      The unaliased <code>@list</code> MAY be used as the value of the <code>@container</code> key within an <a>expanded term definition</a>.
+      Its value MUST be one of the following:
+      <ul>
+        <li><a>string</a>,</li>
+        <li><a>number</a>,</li>
+        <li><a>true</a>,</li>
+        <li><a>false</a>,</li>
+        <li><a>null</a>,</li>
+        <li><a>node object</a>,</li>
+        <li><a>value object</a>, or</li>
+        <li>an <a>array</a> of zero or more of the above possibilities</li>
+      </ul>
+
+      <p>See <a class="sectionRef" href="#sets-and-lists"></a> for further discussion on sets and lists.</p>
+    </dd>
+    <dt><code>@nest</code></dt><dd>
+      The <code>@nest</code> keyword MAY be aliased and MAY be used as a key in a <a>node object</a>.
+      The unaliased <code>@nest</code> MAY be used as the value of a <a>simple term definition</a>,
+      or as a key in an <a>expanded term definition</a>.
+      When used in a <a>node object</a>, its value must be a <a>dictionary</a>.
+      When used in an <a>expanded term definition</a>, its value MUST be a term expanding to <code>@nest</code>.
+      Its value MUST be a <a>string</a>.
+      See <a class="sectionRef" href="#property-nesting"></a> for a further discussion.
+    </dd>
+    <dt><code>@none</code></dt><dd>
+      The <code>@none</code> keyword MAY be aliased and MAY beused as a key in an
+      <a>index map</a>, <a>id map</a>, <a>language map</a>, <a>type map</a>.
+      See <a class="sectionRef" href="#data-indexing"></a>,
+      <a class="sectionRef" href="#language-indexing"></a>,
+      <a class="sectionRef" href="#node-identifier-indexing"></a>,
+      <a class="sectionRef" href="#node-type-indexing"></a>,
+      <a class="sectionRef" href="#named-graph-indexing"></a>, or
+      <a class="sectionRef" href="#named-graph-data-indexing"></a>
+      for a further discussion.</dd>
+    <dt><code>@prefix</code></dt><dd>
+      The <code>@prefix</code> keyword MUST NOT be aliased, and MAY be used as a key in an <a>expanded term definition</a>.
+      Its value MUST be <code>true</code> or <code>false</code>.
+      See <a class="sectionRef" href="#compact-iris"></a>
+      and <a class="sectionRef" href="#context-definitions"></a>
+      for a further discussion.
+    </dd>
+    <dt><code>@reverse</code></dt><dd>
+      The <code>@reverse</code> keyword MAY be aliased and MAY be used as a key in a <a>node object</a>.
+      The unaliased <code>@reverse</code> MAY be used as a key in an <a>expanded term definition</a>.
+      The value of the <code>@reverse</code> key MUST  be an <a>absolute IRI</a>, a <a>relative IRI</a>,
+      or a <a>compact IRI</a> (including <a>blank node identifiers</a>).
+      See <a class="sectionRef" href="#reverse-properties"></a> and
+      <a class="sectionRef" href="#context-definitions"></a> for further discussion.
+    </dd>
+    <dt><code>@set</code></dt><dd>
+      The <code>@set</code> keyword MAY be aliased and MUST be used as a key in a <a>set object</a>.
+      The unaliased <code>@set</code> MAY be used as the value of the <code>@container</code> key within an <a>expanded term definition</a>.
+      Its value MUST be one of the following:
+      <ul>
+        <li><a>string</a>,</li>
+        <li><a>number</a>,</li>
+        <li><a>true</a>,</li>
+        <li><a>false</a>,</li>
+        <li><a>null</a>,</li>
+        <li><a>node object</a>,</li>
+        <li><a>value object</a>, or</li>
+        <li>an <a>array</a> of zero or more of the above possibilities</li>
+      </ul>
+
+      <p>See <a class="sectionRef" href="#sets-and-lists"></a> for further discussion on sets and lists.</p>
+    </dd>
+    <dt><code>@type</code></dt><dd>
+      The <code>@type</code> keyword MAY be aliased and MAY be used as a key in a <a>node object</a> or a <a>value object</a>.
+      The unaliased <code>@type</code> MAY be used as a key in an <a>expanded term definition</a>,
+      or as the value of the <code>@container</code> key within an <a>expanded term definition</a>.
+      The value of the <code>@type</code> key MUST  be a <a>term</a>, <a>absolute IRI</a>, a <a>relative IRI</a>,
+      or a <a>compact IRI</a> (including <a>blank node identifiers</a>).
+      Within an expanded term definition, its value may also be either <code>@id</code> or <code>@vocab</code>.
+      This keyword is described further in <a class="sectionRef" href="#specifying-the-type"></a>
+      and <a class="sectionRef" href="#typed-values"></a>.
+    </dd>
+    <dt><code>@value</code></dt><dd>
+      The <code>@value</code> keyword MAY be aliased and MUST be used as a key in a <a>value object</a>.
+      Its value key MUST be either a <a>string</a>, a <a>number</a>, <a>true</a>, <a>false</a> or <a>null</a>.
+      This keyword is described further in <a class="sectionRef" href="#value-objects"></a>.
+    </dd>
+    <dt><code>@version</code></dt><dd>
+      The <code>@version</code> keyword MUST NOT be aliased and MAY be used as a key in a <a>context definition</a>.
+      Its value MUST be a <a>number</a> with the value <code>1.1</code>.
+      This keyword is described further in <a class="sectionRef" href="#context-definitions"></a>.
+    </dd>
+    <dt><code>@vocab</code></dt><dd>
+      The <code>@vocab</code> keyword MUST NOT be aliased and MAY be used as a key in a <a>context definition</a>
+      or as the value of <code>@type</code> in an <a>expanded term definition</a>.
+      Its value MUST be a <a>absolute IRI</a>, a <a>compact IRI</a>, a <a>blank node identifier</a>, an empty <a>string</a> (""), a <a>term</a>, or <a>null</a>.
+      This keyword is described further in <a class="sectionRef" href="#context-definitions"></a>,
+      and <a class="sectionRef" href="#default-vocabulary"></a>.
+    </dd>
+  </dl>
+</section>
 </section>
 
 <section class="normative">

--- a/index.html
+++ b/index.html
@@ -491,9 +491,18 @@
         language of a JSON-LD document. This keyword is described in
         <a class="sectionRef" href="#string-internationalization"></a>.</dd>
       <dt><code>@type</code></dt>
-      <dd>Used to set the data type of a <a>node</a> or
-        <a>typed value</a>. This keyword is described in
-        <a class="sectionRef" href="#typed-values"></a>.</dd>
+      <dd>Used to set the type of a <a>node</a> or the datatype of a <a>typed value</a>.
+        This keyword is described further in <a class="sectionRef" href="#specifying-the-type"></a>
+        and <a class="sectionRef" href="#typed-values"></a>.
+        <div class="note">The notion of type can be confusing, as both
+          nodes and literal values can have types,
+          but in the <a>data model</a>,
+          these are fundamentally different things.
+          The use of <code>@type</code> to define a type for both <a>node objects</a> and <a>value objects</a>
+          addresses the basic need to type data,
+          be it a literal value or a more complicated <a>resource</a>.
+        </div>
+      </dd>
       <dt><code>@container</code></dt>
       <dd>Used to set the default container type for a <a>term</a>.
         This keyword is described in the following sections:
@@ -1430,6 +1439,86 @@
     type. For a detailed description of the differences, please refer to
     <a class="sectionRef" href="#typed-values"></a>.</p>
 
+</section>
+
+<section class="changed">
+  <h2>Uses of JSON Objects</h2>
+  <p>As a syntax, JSON has only a limited number of syntactic elements:</p>
+  <ul>
+    <li><a>Numbers</a>, which describe literal numeric values,</li>
+    <li><a>Strings</a>, which may describe literal string values, or be used as the keys in a <a>JSON object</a>.</li>
+    <li><a>Boolean</a> <code>true</code> and <code>false</code>, which describe literal boolean values,</li>
+    <li><code>Null</code>, which describes the absense of a value,</li>
+    <li><a>Arrays</a>, which describe an ordered set of values of any type, and</li>
+    <li><a>JSON objects</a>, which provide a set of <a>dictionary members</a>, relating keys with values.</li>
+  </ul>
+
+  <p>The JSON-LD data model allows for a richer set of resources, based on the RDF data mode.
+    The data model is described more fully in <a class="sectionRef" href="#data-model"></a>.
+    JSON-LD uses JSON objects to describe various resources, along with the relationships
+    between these resources:</p>
+  <dl>
+    <dt><a>Node objects</a></dt><dd>
+      Node objects are used to define nodes in the <a>linked data graph</a>
+      which may have both incoming and outgoing edges.
+      Node objects are principle structure for defining <a>resources</a> having <a>properties</a>.
+      See <a class="sectionRef" href="#node-objects"></a> for the normative definition.
+    </dd>
+    <dt><a>Value objects</a></dt><dd>
+      Value objects are used for describing literal nodes in a <a>linked data graph</a>
+      which may have only incoming edges.
+      In JSON, some literal nodes may be described without the use of a <a>JSON object</a>
+      (e.g., <a>numbers</a>, <a>strings</a>, and <a>boolean</a> values),
+      but in the <a data-lt="expansion">expanded form</a>,
+      all literal nodes are described using <a>value objects</a>.
+      See <a class="sectionRef" href="#describing-values"></a> for more information,
+      and <a class="sectionRef" href="#value-objects"></a> for the normative definition.
+    </dd>
+    <dt><a>List Objects</a> and <a>Set objects</a></dt><dd></dd>
+    <dt>Map Objects</dt><dd>
+      JSON-LD uses various forms of <a>dictionaries</a> as ways to more easily access values of a <a>property</a>.
+      <dl>
+        <dt><a>Language Maps</a></dt><dd>
+          Allows mulitple values differing in their associated language to be
+          indexed by <a>language tag</a>.
+          See <a class="sectionRef" href="#language-indexing"></a> for more information,
+          and <a class="sectionRef" href="#language-maps"></a> for the normative definition.
+        </dd>
+        <dt><a>Index Maps</a></dt><dd>
+          Allows multiple values (<a>node objects</a> or <a>value objects</a>) to be indexed by an associated <code>@index</code>.
+          See <a class="sectionRef" href="#data-indexing"></a> for more information,
+          and <a class="sectionRef" href="#index-maps"></a> for the normative definition.
+        </dd>
+        <dt><a>Id Maps</a></dt><dd>
+          Allows multiple <a>node objects</a> to be indexed by an associated <code>@id</code>.
+          See <a class="sectionRef" href="#node-identifier-indexing"></a> for more information,
+          and <a class="sectionRef" href="#id-maps"></a> for the normative definition.
+        </dd>
+        <dt><a>Type Maps</a></dt><dd>
+          Allows multiple <a>node objects</a> to be indexed by an associated <code>@type</code>.
+          See <a class="sectionRef" href="#node-type-indexing"></a> for more information,
+          and <a class="sectionRef" href="#type-maps"></a> for the normative definition.
+        </dd>
+        <dt><a>Named Graph</a> Indexing</dt><dd>
+          Allows multiple <a>named graphs</a> to be indexed by an associated <a>graph name</a>.
+          See <a class="sectionRef" href="#named-graph-indexing"></a> for more information.
+        </dd>
+      </dl>
+    </dd>
+    <dt><a>Graph objects</a></dt><dd>
+      A Graph object is much like a <a>node object</a>, except that it defines a <a>named graph</a>.
+      See <a class="sectionRef" href="#named-graphs"></a> for more information,
+      and <a class="sectionRef" href="#graph-objects"></a> for the normative definition.
+    </dd>
+    <dt><a>Context Definitions</a></dt><dd>
+      A Context Definition uses the <a>JSON object</a> form, but is not itself data in a <a>linked data graph</a>.
+      A Context Definition also may contain expanded term definitions,
+      which are also represented using JSON objects.
+      See <a class="sectionRef" href="#the-context"></a>,
+      <a class="sectionRef" href="#advanced-context-usage"></a> for more information,
+      and <a class="sectionRef" href="#context-definitions"></a> for the normative definition.
+    </dd>
+  </dl>
 </section>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -721,6 +721,11 @@
     to work with for human developers. To address this issue, JSON-LD introduces the notion
     of a <a>context</a> as described in the next section.</p>
 
+  <p>This section only covers the most basic features of JSON-LD. More advanced features,
+    including <a>typed values</a>, <a href="#indexed-values">indexed values</a>, and <a>named graphs</a>,
+    can be found in <a class="sectionRef" href="#advanced-concepts"></a>.</p>
+
+
   <section class="informative">
     <h2>The Context</h2>
 
@@ -1523,18 +1528,6 @@
     from setting one or more types on a <a>node object</a>, as the former does not result in
     new data being added to the graph, while the later manages node types
     through adding additional relationships to the graph.</p>
-
-  <p class="note">This section only covers the most basic features associated with
-    types in JSON-LD. It is worth noting that the <code>@type</code>
-    <a>keyword</a> is not only used to specify the type of a
-    <a>node</a> but also to express <a>typed values</a>
-    (as described in <a class="sectionRef" href="#typed-values"></a>) and to
-    <a data-lt="coercion">type coerce</a> values (as described in
-    <a class="sectionRef" href="#type-coercion"></a>). Specifically, <code>@type</code>
-    cannot be used in a <a>context</a> to define a <a>node</a>'s
-    type. For a detailed description of the differences, please refer to
-    <a class="sectionRef" href="#typed-values"></a>.</p>
-
 </section>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -1238,6 +1238,86 @@
 
 </section>
 
+<section class="changed">
+  <h2>Uses of JSON Objects</h2>
+  <p>As a syntax, JSON has only a limited number of syntactic elements:</p>
+  <ul>
+    <li><a>Numbers</a>, which describe literal numeric values,</li>
+    <li><a>Strings</a>, which may describe literal string values, or be used as the keys in a <a>JSON object</a>.</li>
+    <li><a>Boolean</a> <code>true</code> and <code>false</code>, which describe literal boolean values,</li>
+    <li><code>Null</code>, which describes the absense of a value,</li>
+    <li><a>Arrays</a>, which describe an ordered set of values of any type, and</li>
+    <li><a>JSON objects</a>, which provide a set of <a>dictionary members</a>, relating keys with values.</li>
+  </ul>
+
+  <p>The JSON-LD data model allows for a richer set of resources, based on the RDF data model.
+    The data model is described more fully in <a class="sectionRef" href="#data-model"></a>.
+    JSON-LD uses JSON objects to describe various resources, along with the relationships
+    between these resources:</p>
+  <dl>
+    <dt><a>Node objects</a></dt><dd>
+      Node objects are used to define nodes in the <a>linked data graph</a>
+      which may have both incoming and outgoing edges.
+      Node objects are principle structure for defining <a>resources</a> having <a>properties</a>.
+      See <a class="sectionRef" href="#node-objects"></a> for the normative definition.
+    </dd>
+    <dt><a>Value objects</a></dt><dd>
+      Value objects are used for describing literal nodes in a <a>linked data graph</a>
+      which may have only incoming edges.
+      In JSON, some literal nodes may be described without the use of a <a>JSON object</a>
+      (e.g., <a>numbers</a>, <a>strings</a>, and <a>boolean</a> values),
+      but in the <a data-lt="expansion">expanded form</a>,
+      all literal nodes are described using <a>value objects</a>.
+      See <a class="sectionRef" href="#describing-values"></a> for more information,
+      and <a class="sectionRef" href="#value-objects"></a> for the normative definition.
+    </dd>
+    <dt><a>List Objects</a> and <a>Set objects</a></dt><dd></dd>
+    <dt>Map Objects</dt><dd>
+      JSON-LD uses various forms of <a>dictionaries</a> as ways to more easily access values of a <a>property</a>.
+      <dl>
+        <dt><a>Language Maps</a></dt><dd>
+          Allows mulitple values differing in their associated language to be
+          indexed by <a>language tag</a>.
+          See <a class="sectionRef" href="#language-indexing"></a> for more information,
+          and <a class="sectionRef" href="#language-maps"></a> for the normative definition.
+        </dd>
+        <dt><a>Index Maps</a></dt><dd>
+          Allows multiple values (<a>node objects</a> or <a>value objects</a>) to be indexed by an associated <code>@index</code>.
+          See <a class="sectionRef" href="#data-indexing"></a> for more information,
+          and <a class="sectionRef" href="#index-maps"></a> for the normative definition.
+        </dd>
+        <dt><a>Id Maps</a></dt><dd>
+          Allows multiple <a>node objects</a> to be indexed by an associated <code>@id</code>.
+          See <a class="sectionRef" href="#node-identifier-indexing"></a> for more information,
+          and <a class="sectionRef" href="#id-maps"></a> for the normative definition.
+        </dd>
+        <dt><a>Type Maps</a></dt><dd>
+          Allows multiple <a>node objects</a> to be indexed by an associated <code>@type</code>.
+          See <a class="sectionRef" href="#node-type-indexing"></a> for more information,
+          and <a class="sectionRef" href="#type-maps"></a> for the normative definition.
+        </dd>
+        <dt><a>Named Graph</a> Indexing</dt><dd>
+          Allows multiple <a>named graphs</a> to be indexed by an associated <a>graph name</a>.
+          See <a class="sectionRef" href="#named-graph-indexing"></a> for more information.
+        </dd>
+      </dl>
+    </dd>
+    <dt><a>Graph objects</a></dt><dd>
+      A Graph object is much like a <a>node object</a>, except that it defines a <a>named graph</a>.
+      See <a class="sectionRef" href="#named-graphs"></a> for more information,
+      and <a class="sectionRef" href="#graph-objects"></a> for the normative definition.
+    </dd>
+    <dt><a>Context Definitions</a></dt><dd>
+      A Context Definition uses the <a>JSON object</a> form, but is not itself data in a <a>linked data graph</a>.
+      A Context Definition also may contain expanded term definitions,
+      which are also represented using JSON objects.
+      See <a class="sectionRef" href="#the-context"></a>,
+      <a class="sectionRef" href="#advanced-context-usage"></a> for more information,
+      and <a class="sectionRef" href="#context-definitions"></a> for the normative definition.
+    </dd>
+  </dl>
+</section>
+
 <section class="informative">
   <h2>Specifying the Type</h2>
 
@@ -1250,7 +1330,7 @@
     type is a <em>Person</em>; making this explicit with <code>@type</code> helps
     to clarify the association.</p>
   
-  <p>The type of a particular node can be specified using the <code>@type</code>
+  <p>The type of a particular <a>node</a> can be specified using the <code>@type</code>
     <a>keyword</a>. In Linked Data, types are uniquely
     identified with an <a>IRI</a>.</p>
 
@@ -1373,7 +1453,7 @@
     </pre>
   </aside>
 
-  <p>The value of an <code>@type</code> key may also be a <a>term</a> defined in the <a>active context</a>:</p>
+  <p>The value of a <code>@type</code> key may also be a <a>term</a> defined in the <a>active context</a>:</p>
 
   <aside class="example ds-selector-tabs"
          title="Using a term to specify the type">
@@ -1428,6 +1508,22 @@
     </pre>
   </aside>
 
+  <p class="changed">In addition to setting the type of nodes,
+    <code>@type</code> can also be used to set the type of a value
+    to create a <a>typed value</a>.
+    This use of <code>@type</code> is similar to that used to define the type of a <a>node object</a>,
+    but value objects are restricted to having just a single type.
+    The use of @type to create typed values is discussed more fully in <a class="sectionRef" href="#typed-values"></a>.</p>
+
+  <p class="changed">Typed values can also be defined implicitly, by specifying
+    @type in an expanded term definition.
+    This is covered more fully in <a class="sectionRef" href="#type-coercion"></a>.</p>
+
+  <p class="note">The ability coerce a value using a <a>term definition</a> is distinct
+    from setting one or more types on a <a>node object</a>, as the former does not result in
+    new data being added to the graph, while the later manages node types
+    through adding additional relationships to the graph.</p>
+
   <p class="note">This section only covers the most basic features associated with
     types in JSON-LD. It is worth noting that the <code>@type</code>
     <a>keyword</a> is not only used to specify the type of a
@@ -1439,86 +1535,6 @@
     type. For a detailed description of the differences, please refer to
     <a class="sectionRef" href="#typed-values"></a>.</p>
 
-</section>
-
-<section class="changed">
-  <h2>Uses of JSON Objects</h2>
-  <p>As a syntax, JSON has only a limited number of syntactic elements:</p>
-  <ul>
-    <li><a>Numbers</a>, which describe literal numeric values,</li>
-    <li><a>Strings</a>, which may describe literal string values, or be used as the keys in a <a>JSON object</a>.</li>
-    <li><a>Boolean</a> <code>true</code> and <code>false</code>, which describe literal boolean values,</li>
-    <li><code>Null</code>, which describes the absense of a value,</li>
-    <li><a>Arrays</a>, which describe an ordered set of values of any type, and</li>
-    <li><a>JSON objects</a>, which provide a set of <a>dictionary members</a>, relating keys with values.</li>
-  </ul>
-
-  <p>The JSON-LD data model allows for a richer set of resources, based on the RDF data model.
-    The data model is described more fully in <a class="sectionRef" href="#data-model"></a>.
-    JSON-LD uses JSON objects to describe various resources, along with the relationships
-    between these resources:</p>
-  <dl>
-    <dt><a>Node objects</a></dt><dd>
-      Node objects are used to define nodes in the <a>linked data graph</a>
-      which may have both incoming and outgoing edges.
-      Node objects are principle structure for defining <a>resources</a> having <a>properties</a>.
-      See <a class="sectionRef" href="#node-objects"></a> for the normative definition.
-    </dd>
-    <dt><a>Value objects</a></dt><dd>
-      Value objects are used for describing literal nodes in a <a>linked data graph</a>
-      which may have only incoming edges.
-      In JSON, some literal nodes may be described without the use of a <a>JSON object</a>
-      (e.g., <a>numbers</a>, <a>strings</a>, and <a>boolean</a> values),
-      but in the <a data-lt="expansion">expanded form</a>,
-      all literal nodes are described using <a>value objects</a>.
-      See <a class="sectionRef" href="#describing-values"></a> for more information,
-      and <a class="sectionRef" href="#value-objects"></a> for the normative definition.
-    </dd>
-    <dt><a>List Objects</a> and <a>Set objects</a></dt><dd></dd>
-    <dt>Map Objects</dt><dd>
-      JSON-LD uses various forms of <a>dictionaries</a> as ways to more easily access values of a <a>property</a>.
-      <dl>
-        <dt><a>Language Maps</a></dt><dd>
-          Allows mulitple values differing in their associated language to be
-          indexed by <a>language tag</a>.
-          See <a class="sectionRef" href="#language-indexing"></a> for more information,
-          and <a class="sectionRef" href="#language-maps"></a> for the normative definition.
-        </dd>
-        <dt><a>Index Maps</a></dt><dd>
-          Allows multiple values (<a>node objects</a> or <a>value objects</a>) to be indexed by an associated <code>@index</code>.
-          See <a class="sectionRef" href="#data-indexing"></a> for more information,
-          and <a class="sectionRef" href="#index-maps"></a> for the normative definition.
-        </dd>
-        <dt><a>Id Maps</a></dt><dd>
-          Allows multiple <a>node objects</a> to be indexed by an associated <code>@id</code>.
-          See <a class="sectionRef" href="#node-identifier-indexing"></a> for more information,
-          and <a class="sectionRef" href="#id-maps"></a> for the normative definition.
-        </dd>
-        <dt><a>Type Maps</a></dt><dd>
-          Allows multiple <a>node objects</a> to be indexed by an associated <code>@type</code>.
-          See <a class="sectionRef" href="#node-type-indexing"></a> for more information,
-          and <a class="sectionRef" href="#type-maps"></a> for the normative definition.
-        </dd>
-        <dt><a>Named Graph</a> Indexing</dt><dd>
-          Allows multiple <a>named graphs</a> to be indexed by an associated <a>graph name</a>.
-          See <a class="sectionRef" href="#named-graph-indexing"></a> for more information.
-        </dd>
-      </dl>
-    </dd>
-    <dt><a>Graph objects</a></dt><dd>
-      A Graph object is much like a <a>node object</a>, except that it defines a <a>named graph</a>.
-      See <a class="sectionRef" href="#named-graphs"></a> for more information,
-      and <a class="sectionRef" href="#graph-objects"></a> for the normative definition.
-    </dd>
-    <dt><a>Context Definitions</a></dt><dd>
-      A Context Definition uses the <a>JSON object</a> form, but is not itself data in a <a>linked data graph</a>.
-      A Context Definition also may contain expanded term definitions,
-      which are also represented using JSON objects.
-      See <a class="sectionRef" href="#the-context"></a>,
-      <a class="sectionRef" href="#advanced-context-usage"></a> for more information,
-      and <a class="sectionRef" href="#context-definitions"></a> for the normative definition.
-    </dd>
-  </dl>
 </section>
 </section>
 


### PR DESCRIPTION
* Improved `@type` keyword definition, and added _Uses of JSON Objects_ section.
* Add a section on keywords to the grammar, and slight improvement to type values.

Addresses #77.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/92.html" title="Last updated on Nov 17, 2018, 7:27 PM GMT (a42ebb3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/92/337f184...a42ebb3.html" title="Last updated on Nov 17, 2018, 7:27 PM GMT (a42ebb3)">Diff</a>