### PR TITLE
Remove the need for wrapping comment-open/comment-close text in data blocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -8577,10 +8577,11 @@ the data type to be specified explicitly with each piece of data.</p>
 
 <section class="changed"><h2>Embedding JSON-LD in HTML Documents</h2>
 
-  <p>HTML <a data-cite="HTML52/semantics-scripting.html#the-script-element">script elements</a> can be used to embed blocks of data in documents.
-    This way, JSON-LD content can be easily embedded in HTML [[HTML52]] by placing
-    it in a script element with the <code>type</code> attribute set to
-    <code>application/ld+json</code>.</p>
+  <p>
+    JSON-LD content can be easily embedded in HTML [[HTML52]] by placing
+    it in a <a data-cite="HTML52/semantics-scripting.html#the-script-element">Script element</a> with the <code>type</code> attribute set to
+    <code>application/ld+json</code>. Doing so creates a
+    <a data-cite="https://www.w3.org/TR/html52/semantics-scripting.html#data-block">data block</a>.</p>
 
    <aside class="example ds-selector-tabs"
            title="Embedding JSON-LD in HTML">

--- a/index.html
+++ b/index.html
@@ -8726,99 +8726,101 @@ the data type to be specified explicitly with each piece of data.</p>
     </pre>
   </aside>
 
-  <p>When processing a JSON-LD
-    <a data-cite="HTML52/semantics-scripting.html#the-script-element">script element</a>,
-    the <a data-cite="HTML52/infrastructure.html#document-base-url">Document Base URL</a>
-    of the containing HTML document,
-    as defined in [[HTML52]],
-    is used to establish the default <a>base IRI</a> of the enclosed
-    JSON-LD content.</p>
+  <section><h3>Inheriting base IRI from HTML's <code>base</code> element</h3>
+    <p>When processing a JSON-LD
+      <a data-cite="HTML52/semantics-scripting.html#the-script-element">script element</a>,
+      the <a data-cite="HTML52/infrastructure.html#document-base-url">Document Base URL</a>
+      of the containing HTML document,
+      as defined in [[HTML52]],
+      is used to establish the default <a>base IRI</a> of the enclosed
+      JSON-LD content.</p>
 
-    <p class="issue atrisk" data-number="23">
-      The use of the <a data-cite="HTML52/infrastructure.html#document-base-url">Document Base URL</a>
-      from [[HTML52]] for setting the <a>base IRI</a> of the enclosed JSON-LD
-      is an experimental feature, which may be changed in a future version of this specification.
-    </p>
+      <p class="issue atrisk" data-number="23">
+        The use of the <a data-cite="HTML52/infrastructure.html#document-base-url">Document Base URL</a>
+        from [[HTML52]] for setting the <a>base IRI</a> of the enclosed JSON-LD
+        is an experimental feature, which may be changed in a future version of this specification.
+      </p>
 
-   <aside class="example ds-selector-tabs"
-           title="Using the document base URL to establish the default base IRI">
-    <div class="selectors">
-      <button class="selected" data-selects="original">Original</button>
-      <button data-selects="expanded">Expanded</button>
-      <button data-selects="statements">Statements</button>
-      <button data-selects="turtle">Turtle</button>
-    </div>
-    <pre class="original selected" data-transform="updateExample"
-         data-content-type="text/html">
-    <!--
-    ****<html>
-      <head>
-        <base href="http://dbpedia.org/resource/"/>****
-        <script type="application/ld+json">
-        < ! - -
-        {
-          "@context": "https://json-ld.org/contexts/person.jsonld",
-          "@id": ****"John_Lennon"****,
-          "name": "John Lennon",
-          "born": "1940-10-09",
-          "spouse": ****"Cynthia_Lennon"****
-        }
-        - - >
-        </script>
-      ****</head>
-    </html>****
-    -->
-    </pre>
-    <pre class="expanded"
-         data-transform="updateExample"
-         data-result-for="Using the document base URL to establish the default base IRI-original">
-    <!--
-    [{
-      "@id": "http://dbpedia.org/resource/John_Lennon",
-      "http://xmlns.com/foaf/0.1/name": [{"@value": "John Lennon"}],
-      "http://schema.org/birthDate": [
-        {"@value": "1940-10-09", "@type": "http://www.w3.org/2001/XMLSchema#date"}
-      ],
-      "http://schema.org/spouse": [
-        {"@id": "http://dbpedia.org/resource/Cynthia_Lennon"}
-      ]
-    }]
-    -->
-    </pre>
-    <table class="statements"
+     <aside class="example ds-selector-tabs"
+             title="Using the document base URL to establish the default base IRI">
+      <div class="selectors">
+        <button class="selected" data-selects="original">Original</button>
+        <button data-selects="expanded">Expanded</button>
+        <button data-selects="statements">Statements</button>
+        <button data-selects="turtle">Turtle</button>
+      </div>
+      <pre class="original selected" data-transform="updateExample"
+           data-content-type="text/html">
+      <!--
+      ****<html>
+        <head>
+          <base href="http://dbpedia.org/resource/"/>****
+          <script type="application/ld+json">
+          < ! - -
+          {
+            "@context": "https://json-ld.org/contexts/person.jsonld",
+            "@id": ****"John_Lennon"****,
+            "name": "John Lennon",
+            "born": "1940-10-09",
+            "spouse": ****"Cynthia_Lennon"****
+          }
+          - - >
+          </script>
+        ****</head>
+      </html>****
+      -->
+      </pre>
+      <pre class="expanded"
+           data-transform="updateExample"
+           data-result-for="Using the document base URL to establish the default base IRI-original">
+      <!--
+      [{
+        "@id": "http://dbpedia.org/resource/John_Lennon",
+        "http://xmlns.com/foaf/0.1/name": [{"@value": "John Lennon"}],
+        "http://schema.org/birthDate": [
+          {"@value": "1940-10-09", "@type": "http://www.w3.org/2001/XMLSchema#date"}
+        ],
+        "http://schema.org/spouse": [
+          {"@id": "http://dbpedia.org/resource/Cynthia_Lennon"}
+        ]
+      }]
+      -->
+      </pre>
+      <table class="statements"
+             data-result-for="Using the document base URL to establish the default base IRI-expanded"
+             data-to-rdf>
+        <thead><tr><th>Subject</th><th>Property</th><th>Value</th><th>Value Type</th></tr></thead>
+        <tbody>
+          <tr><td>http://dbpedia.org/resource/John_Lennon</td><td>foaf:name</td><td>John Lennon</td><td>&nbsp;</td></tr>
+          <tr><td>http://dbpedia.org/resource/John_Lennon</td><td>schema:birthDate</td><td>1940-10-09</td><td>xsd:date</td></tr>
+          <tr><td>http://dbpedia.org/resource/John_Lennon</td><td>schema:spouse</td><td>http://dbpedia.org/resource/Cynthia_Lennon</td><td>&nbsp;</td></tr>
+        </tbody>
+      </table>
+      <pre class="turtle"
+           data-content-type="text/turtle"
+           data-transform="updateExample"
            data-result-for="Using the document base URL to establish the default base IRI-expanded"
            data-to-rdf>
-      <thead><tr><th>Subject</th><th>Property</th><th>Value</th><th>Value Type</th></tr></thead>
-      <tbody>
-        <tr><td>http://dbpedia.org/resource/John_Lennon</td><td>foaf:name</td><td>John Lennon</td><td>&nbsp;</td></tr>
-        <tr><td>http://dbpedia.org/resource/John_Lennon</td><td>schema:birthDate</td><td>1940-10-09</td><td>xsd:date</td></tr>
-        <tr><td>http://dbpedia.org/resource/John_Lennon</td><td>schema:spouse</td><td>http://dbpedia.org/resource/Cynthia_Lennon</td><td>&nbsp;</td></tr>
-      </tbody>
-    </table>
-    <pre class="turtle"
-         data-content-type="text/turtle"
-         data-transform="updateExample"
-         data-result-for="Using the document base URL to establish the default base IRI-expanded"
-         data-to-rdf>
-    <!--
-    @base <http://dbpedia.org/resource/> .
-    @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-    @prefix schema: <http://schema.org/> .
-    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+      <!--
+      @base <http://dbpedia.org/resource/> .
+      @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+      @prefix schema: <http://schema.org/> .
+      @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-    <John_Lennon> foaf:name "John Lennon";
-       schema:birthDate "1940-10-09"^^xsd:date;
-       schema:spouse <Cynthia_Lennon> .
-    -->
-    </pre>
-  </aside>
+      <John_Lennon> foaf:name "John Lennon";
+         schema:birthDate "1940-10-09"^^xsd:date;
+         schema:spouse <Cynthia_Lennon> .
+      -->
+      </pre>
+    </aside>
 
-  <p>HTML allows for <a data-cite="HTML52/infrastructure.html#dynamic-changes-to-base-urls">Dynamic changes to base URLs</a>.
-    This specification does not require any specific behavior,
-    and to ensure that all systems process the <a>base IRI</a> equivalently, authors SHOULD
-    either use <a>absolute IRIs</a>, or explicitly as defined in <a href="#base-iri" class="sectionRef"></a>.
-    Implementations (particularly those natively operating in the [[!DOM]]) MAY take into consideration
-    <a data-cite="HTML52/infrastructure.html#dynamic-changes-to-base-urls">Dynamic changes to base URLs</a>.</p>
+    <p>HTML allows for <a data-cite="HTML52/infrastructure.html#dynamic-changes-to-base-urls">Dynamic changes to base URLs</a>.
+      This specification does not require any specific behavior,
+      and to ensure that all systems process the <a>base IRI</a> equivalently, authors SHOULD
+      either use <a>absolute IRIs</a>, or explicitly as defined in <a href="#base-iri" class="sectionRef"></a>.
+      Implementations (particularly those natively operating in the [[!DOM]]) MAY take into consideration
+      <a data-cite="HTML52/infrastructure.html#dynamic-changes-to-base-urls">Dynamic changes to base URLs</a>.</p>
+  </section>
 
   <section><h3>Restrictions for contents of JSON-LD <code>script</code> elements</h3>
     <p class="issue atrisk">This section adds additional requirements for escaping

--- a/index.html
+++ b/index.html
@@ -8581,7 +8581,7 @@ the data type to be specified explicitly with each piece of data.</p>
     JSON-LD content can be easily embedded in HTML [[HTML52]] by placing
     it in a <a data-cite="HTML52/semantics-scripting.html#the-script-element">Script element</a> with the <code>type</code> attribute set to
     <code>application/ld+json</code>. Doing so creates a
-    <a data-cite="https://www.w3.org/TR/html52/semantics-scripting.html#data-block">data block</a>.</p>
+    <a data-cite="HTML52/semantics-scripting.html#data-block">data block</a>.</p>
 
    <aside class="example ds-selector-tabs"
            title="Embedding JSON-LD in HTML">
@@ -8857,7 +8857,7 @@ the data type to be specified explicitly with each piece of data.</p>
         "@context": "http://schema.org/",
         "@type": "WebPageElement",
         "name": "Encoding Issues",
-        "description": "Issues list such as unescaped &lt;/script&gt; or - - &gt;"
+        "description": "Issues list such as unescaped &lt;/script&gt; or - -&gt;"
       }
       </script>
       -->

--- a/index.html
+++ b/index.html
@@ -8900,7 +8900,7 @@ the data type to be specified explicitly with each piece of data.</p>
       of the script element within the HTML document located by a URL (see [[!DOM]]).
       A <a>JSON-LD processor</a> MUST extract only the specified data block's contents
       parsing it as a standalone <a>JSON-LD document</a>
-      and MUST NOT create a <a>dataset</a>.</p>
+      and MUST NOT merge the result with any other markup from the same HTML document.</p>
 
     <p>For example, given an HTML document located at <code>http://example.com/document</code>,
       a script element identified by "name" can be targeted using the URL

--- a/index.html
+++ b/index.html
@@ -8756,7 +8756,6 @@ the data type to be specified explicitly with each piece of data.</p>
         <head>
           <base href="http://dbpedia.org/resource/"/>****
           <script type="application/ld+json">
-          < ! - -
           {
             "@context": "https://json-ld.org/contexts/person.jsonld",
             "@id": ****"John_Lennon"****,
@@ -8764,7 +8763,6 @@ the data type to be specified explicitly with each piece of data.</p>
             "born": "1940-10-09",
             "spouse": ****"Cynthia_Lennon"****
           }
-          - - >
           </script>
         ****</head>
       </html>****
@@ -8849,7 +8847,6 @@ the data type to be specified explicitly with each piece of data.</p>
       <div class="selectors">
         <button class="selected" data-selects="original">Original</button>
         <button data-selects="expanded">Expanded</button>
-        <button data-selects="statements">Statements</button>
         <button data-selects="turtle">Turtle</button>
       </div>
       <pre class="original selected" data-transform="updateExample"
@@ -8860,43 +8857,36 @@ the data type to be specified explicitly with each piece of data.</p>
         "@context": "http://schema.org/",
         "@type": "WebPageElement",
         "name": "Encoding Issues",
-        "description": "Issues list such as unescaped &lt;/script&gt; or --&gt;"
+        "description": "Issues list such as unescaped &lt;/script&gt; or - - &gt;"
       }
       </script>
       -->
       </pre>
       <pre class="expanded"
            data-transform="updateExample"
-           data-result-for="Embedding JSON-LD in HTML with comments-original">
+           data-result-for="Embedding JSON-LD containing HTML in HTML-original">
       <!--
       [{
-        "@type": "http://schema.org/WebPageElement",
+        "@type": ["http://schema.org/WebPageElement"],
         "http://schema.org/name": [{"@value": "Encoding Issues"}],
         "http://schema.org/description": [
-          {"@value": "Issues list such as unescaped &lt;/script&gt; or --&gt;"}
+          {"@value": "Issues list such as unescaped </script> or - - >"}
         ]
       }]
       -->
       </pre>
-      <table class="statements"
-             data-result-for="Embedding JSON-LD in HTML with comments-expanded"
-             data-to-rdf>
-        <thead><tr><th>Subject</th><th>Property</th><th>Value</th><th>Value Type</th></tr></thead>
-        <tbody>
-          <tr><td>_:b0</td><td>schema:name</td><td>Encoding Issues</td><td>&nbsp;</td></tr>
-          <tr><td>_:b0</td><td>schema:description</td><td>Issues list such as unescaped &amp;lt;/script&amp;gt; or --&amp;gt;</td><td>&nbsp;</td></tr>
-        </tbody>
-      </table>
       <pre class="turtle"
            data-content-type="text/turtle"
            data-transform="updateExample"
-           data-result-for="Embedding JSON-LD in HTML with comments-expanded"
+           data-result-for="Embedding JSON-LD containing HTML in HTML-expanded"
            data-to-rdf>
       <!--
       @prefix schema: <http://schema.org/> .
 
-      <> schema:name "Encoding Issues";
-         schema:description "Issues list such as unescaped &lt;/script&gt; or --&gt;" .
+      [ a schema:WebPageElement;
+        schema:name "Encoding Issues";
+        schema:description "Issues list such as unescaped </script> or - - >"
+      ] .
       -->
       </pre>
     </aside>

--- a/index.html
+++ b/index.html
@@ -8726,10 +8726,6 @@ the data type to be specified explicitly with each piece of data.</p>
     </pre>
   </aside>
 
-  <p>Otherwise, unless a specific script is targeted
-    (see <a href="#locating-a-specific-json-ld-script-element" class="sectionRef"></a>),
-    only the first script element of <code>type</code> <code>application/ld+json</code> is used.</p>
-
   <p>When processing a JSON-LD
     <a data-cite="HTML52/semantics-scripting.html#the-script-element">script element</a>,
     the <a data-cite="HTML52/infrastructure.html#document-base-url">Document Base URL</a>

--- a/index.html
+++ b/index.html
@@ -8905,7 +8905,11 @@ the data type to be specified explicitly with each piece of data.</p>
       <a data-cite="HTML52/semantics-scripting.html#the-script-element">script element</a>
       within an HTML document may be located using
       a fragment identifier matching the <a data-cite="DOM#concept-id">unique identifier</a>
-      of the script element within the HTML document located by a URL (see [[!DOM]]).</p>
+      of the script element within the HTML document located by a URL (see [[!DOM]]).
+      A <a>JSON-LD processor</a> MUST extract only the specified data block's contents
+      parsing it as a standalone <a>JSON-LD document</a>
+      and MUST NOT create a <a>dataset</a>.</p>
+
     <p>For example, given an HTML document located at <code>http://example.com/document</code>,
       a script element identified by "name" can be targeted using the URL
       <code>http://example.com/document#name</code>.</p>

--- a/index.html
+++ b/index.html
@@ -8824,31 +8824,19 @@ the data type to be specified explicitly with each piece of data.</p>
     <a data-cite="HTML52/infrastructure.html#dynamic-changes-to-base-urls">Dynamic changes to base URLs</a>.</p>
 
   <section><h3>Restrictions for contents of JSON-LD <code>script</code> elements</h3>
-    <p class="issue atrisk">As HTML entities and comments are not allowable in
-      JSON, the use of comments, escapes,
-      and <a data-cite="HTML5/syntax.html#character-references">HTML Character references</a>
-      is subject to further discussion in the Working Group.</p>
+    <p class="issue atrisk">This section adds additional requirements for escaping
+      certain JSON values when embedding that JSON within HTML. This approach
+      is consequently subject to further discussion in the Working Group.</p>
 
     <p>Depending on how the HTML document is served, certain strings may need
-      to be escaped. In particular, the content MAY be enclosed
-      in the HTML <em>comment-open</em> (<code>&lt;!--</code>) and <em>comment-close</em> (<code>--&gt;</code>) text sequences.</p>
-    <p>As described in HTML <a data-cite="HTML52/semantics-scripting.html#restrictions-for-contents-of-script-elements">Restrictions for contents of <code>&lt;script&gt;</code> elements</a>
-      the <a data-cite="DOM#dom-node-textcontent">textContent</a> of a script element may include balanced comments
-      and other text which complicate extracting the JSON-LD content from a <a data-cite="HTML52/semantics-scripting.html#data-block">data blocks</a>.
-      JSON-LD places further restrictions on the contents of
-      <a data-cite="HTML52/semantics-scripting.html#the-script-element">script elements</a> containing JSON-LD.</p>
-    <p>A JSON-LD script element MAY begin with an optional <em>comment-open</em> surrounded by any amount of <a data-cite="HTML52/infrastructure.html#space-characters">space characters</a>,
-      followed by valid JSON and ending with an optional <em>comment-close</em> surrounded by any amount of <a data-cite="HTML52/infrastructure.html#space-characters">space characters</a>.
-      Any content within the JSON content which can be confused with a <em>comment-open</em>, <em>script-open</em>,
-      <em>comment-close</em>, or <em>script-close</em> MUST be escaped using a REVERSE SOLIDUS (<code>\</code>) character
-      as follows:</p>
-    <ul>
-      <li><code>&lt;!--</code>      → <code>&lt;\!--</code></li>
-      <li><code>&lt;script</code>   → <code>&lt;\script</code></li>
-      <li><code>--&gt;</code>       → <code>--\&gt;</code></li>
-      <li><code>&lt;/script</code>  → <code>&lt;\/script</code></li>
-    </ul>
-    <p>Additionally, content of a script element MAY be escaped using <a data-cite="HTML5/syntax.html#character-references">HTML Character references</a>, such as the following:</p>
+      to be escaped to prevent disrupting the HTML parsing algorithm.</p>
+
+    <p>Due to the HTML <a data-cite="HTML52/semantics-scripting.html#restrictions-for-contents-of-script-elements">Restrictions for contents of <code>&lt;script&gt;</code> elements</a>
+      additional encoding restrictions are placed on JSON-LD data contained in
+      <a data-cite="HTML52/semantics-scripting.html#the-script-element">script elements</a>.</p>
+    <p>A JSON-LD script element MUST contain only valid JSON.
+      Any strings within the JSON content which contains text which can be confused with a <em>comment-open</em>, <em>script-open</em>,
+      <em>comment-close</em>, or <em>script-close</em> MUST be escaped using <a data-cite="HTML5/syntax.html#character-references">HTML Character references</a>, such as the following:</p>
     <ul>
       <li><code>&amp;amp;</code>  → &amp; (<a href="/wiki/Ampersand" title="Ampersand">ampersand</a>, U+0026)</li>
       <li><code>&amp;lt;</code>   → &lt; (less-than sign, U+003C)</li>
@@ -8856,14 +8844,9 @@ the data type to be specified explicitly with each piece of data.</p>
       <li><code>&amp;quot;</code> → " (quotation mark, U+0022)</li>
       <li><code>&amp;apos;</code> → ' (apostrophe, U+0027)</li>
     </ul>
-    <p>JSON-LD Processors MUST remove surrounding <em>comment-open</em> and <em>comment-close</em>
-      sequences, unescape any escaped <em>comment-open</em>, <em>comment-close</em>,
-      <em>script-open</em>, and <em>script-close</em> sequences,
-      and turn <a data-cite="HTML5/syntax.html#character-references">HTML Character references</a> into the corresponding Unicode.
-    </p>
 
      <aside class="example ds-selector-tabs"
-             title="Embedding JSON-LD in HTML with comments">
+             title="Embedding JSON-LD containing HTML in HTML">
       <div class="selectors">
         <button class="selected" data-selects="original">Original</button>
         <button data-selects="expanded">Expanded</button>
@@ -8874,15 +8857,12 @@ the data type to be specified explicitly with each piece of data.</p>
            data-content-type="text/html">
       <!--
       <script type="application/ld+json">
-      < ! - -
       {
-        "@context": "https://json-ld.org/contexts/person.jsonld",
-        "@id": "http://dbpedia.org/resource/John_Lennon",
-        "name": "John Lennon",
-        "born": "1940-10-09",
-        "spouse": "http://dbpedia.org/resource/Cynthia_Lennon"
+        "@context": "http://schema.org/",
+        "@type": "WebPageElement",
+        "name": "Encoding Issues",
+        "description": "Issues list such as unescaped &lt;/script&gt; or --&gt;"
       }
-      - - >
       </script>
       -->
       </pre>
@@ -8891,13 +8871,10 @@ the data type to be specified explicitly with each piece of data.</p>
            data-result-for="Embedding JSON-LD in HTML with comments-original">
       <!--
       [{
-        "@id": "http://dbpedia.org/resource/John_Lennon",
-        "http://xmlns.com/foaf/0.1/name": [{"@value": "John Lennon"}],
-        "http://schema.org/birthDate": [
-          {"@value": "1940-10-09", "@type": "http://www.w3.org/2001/XMLSchema#date"}
-        ],
-        "http://schema.org/spouse": [
-          {"@id": "http://dbpedia.org/resource/Cynthia_Lennon"}
+        "@type": "http://schema.org/WebPageElement",
+        "http://schema.org/name": [{"@value": "Encoding Issues"}],
+        "http://schema.org/description": [
+          {"@value": "Issues list such as unescaped &lt;/script&gt; or --&gt;"}
         ]
       }]
       -->
@@ -8907,9 +8884,8 @@ the data type to be specified explicitly with each piece of data.</p>
              data-to-rdf>
         <thead><tr><th>Subject</th><th>Property</th><th>Value</th><th>Value Type</th></tr></thead>
         <tbody>
-          <tr><td>http://dbpedia.org/resource/John_Lennon</td><td>foaf:name</td><td>John Lennon</td><td>&nbsp;</td></tr>
-          <tr><td>http://dbpedia.org/resource/John_Lennon</td><td>schema:birthDate</td><td>1940-10-09</td><td>xsd:date</td></tr>
-          <tr><td>http://dbpedia.org/resource/John_Lennon</td><td>schema:spouse</td><td>http://dbpedia.org/resource/Cynthia_Lennon</td><td>&nbsp;</td></tr>
+          <tr><td>_:b0</td><td>schema:name</td><td>Encoding Issues</td><td>&nbsp;</td></tr>
+          <tr><td>_:b0</td><td>schema:description</td><td>Issues list such as unescaped &amp;lt;/script&amp;gt; or --&amp;gt;</td><td>&nbsp;</td></tr>
         </tbody>
       </table>
       <pre class="turtle"
@@ -8918,13 +8894,10 @@ the data type to be specified explicitly with each piece of data.</p>
            data-result-for="Embedding JSON-LD in HTML with comments-expanded"
            data-to-rdf>
       <!--
-      @prefix foaf: <http://xmlns.com/foaf/0.1/> .
       @prefix schema: <http://schema.org/> .
-      @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-      <http://dbpedia.org/resource/John_Lennon> foaf:name "John Lennon";
-         schema:birthDate "1940-10-09"^^xsd:date;
-         schema:spouse <http://dbpedia.org/resource/Cynthia_Lennon> .
+      <> schema:name "Encoding Issues";
+         schema:description "Issues list such as unescaped &lt;/script&gt; or --&gt;" .
       -->
       </pre>
     </aside>


### PR DESCRIPTION
Addresses the concerns expressed in #96.

This PR also includes putting the `<base>` handling content in its own section, and clarifies the extraction of a single, targeted data block. I can move those to separate PRs if desired, as they do introduce requirements unrelated to the topic in #96. They do clarify/specify the use of targeting vs. not targeting specific data blocks. But my apologies for the mixed PR.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/97.html" title="Last updated on Nov 30, 2018, 7:08 PM GMT (63017bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/97/3320d83...63017bd.html" title="Last updated on Nov 30, 2018, 7:08 PM GMT (63017bd)">Diff</a>