### PR TITLE
Clarify that language map values of `@none` are strings

### DIFF
--- a/index.html
+++ b/index.html
@@ -6009,8 +6009,8 @@ the data type to be specified explicitly with each piece of data.</p>
 
   <p class="changed">If the <a>processing mode</a> is set to <code>json-ld-1.1</code>,
     the special index <code>@none</code> is used for indexing
-    data which does not have a language, which is useful to maintain
-    a normalized representation.</p>
+    strings which do not have a language; this is useful to maintain
+    a normalized representation for string values not having a datatype.</p>
 
   <aside class="example ds-selector-tabs changed"
          title="Indexing languaged-tagged strings using @none for no language">


### PR DESCRIPTION
and not arbitrary data.

Fixes #102.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/104.html" title="Last updated on Dec 6, 2018, 10:25 PM GMT (748466c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/104/b97a16d...748466c.html" title="Last updated on Dec 6, 2018, 10:25 PM GMT (748466c)">Diff</a>