### PR TITLE
Make requirement for entity encoding non-normative

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: git://github.com/ruby-rdf/json-ld.git
-  revision: 488d5e7737d401bb83a246248ad2f921c56938c4
+  revision: a26c3205d006550f85162848a4a2bc3366b39970
   branch: develop
   specs:
     json-ld (3.0.2)
-      multi_json (~> 1.12)
-      rdf (>= 2.2.8, < 4.0)
+      multi_json (~> 1.13)
+      rdf (~> 3.0, >= 3.0.4)
 
 GEM
   remote: https://rubygems.org/
@@ -16,7 +16,7 @@ GEM
       i18n
     builder (3.2.3)
     colorize (0.8.1)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.3)
     connection_pool (2.2.2)
     ebnf (1.1.3)
       rdf (~> 3.0)
@@ -29,9 +29,9 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     htmlentities (4.3.4)
-    i18n (1.1.0)
+    i18n (1.1.1)
       concurrent-ruby (~> 1.0)
-    json-ld-preloaded (3.0.1)
+    json-ld-preloaded (3.0.2)
       json-ld (~> 3.0)
       multi_json (~> 1.12)
       rdf (~> 3.0)
@@ -76,8 +76,8 @@ GEM
     nokogumbo (1.5.0)
       nokogiri
     public_suffix (3.0.3)
-    rake (12.3.1)
-    rdf (3.0.4)
+    rake (12.3.2)
+    rdf (3.0.7)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
     rdf-aggregate-repo (2.2.1)
@@ -126,7 +126,7 @@ GEM
     rdf-turtle (3.0.3)
       ebnf (~> 1.1)
       rdf (~> 3.0)
-    rdf-vocab (3.0.3)
+    rdf-vocab (3.0.4)
       rdf (~> 3.0)
     rdf-xsd (3.0.1)
       rdf (~> 3.0)
@@ -146,13 +146,13 @@ GEM
       rdf-xsd (~> 3.0)
       sparql-client (~> 3.0)
       sxp (~> 1.0)
-    sparql-client (3.0.0)
+    sparql-client (3.0.1)
       net-http-persistent (>= 2.9, < 4)
       rdf (~> 3.0)
     sxp (1.0.1)
       rdf (>= 2.2, < 4.0)
     temple (0.8.0)
-    tilt (2.0.8)
+    tilt (2.0.9)
 
 PLATFORMS
   ruby
@@ -166,4 +166,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.16.4
+   1.17.1

--- a/common/extract-examples.rb
+++ b/common/extract-examples.rb
@@ -303,7 +303,6 @@ ARGV.each do |input|
     # Perform example syntactic validation based on extension
     case ex[:ext]
     when 'json', 'jsonld', 'jsonldf'
-      content = CGI.unescapeHTML(content)
       begin
         ::JSON.parse(content)
       rescue JSON::ParserError => exception
@@ -327,9 +326,7 @@ ARGV.each do |input|
         ex[:base] = html_base.to_s if html_base
 
         script_content = doc.at_xpath(xpath)
-        
-        # Remove (faked) XML comments and unescape sequences
-        content = CGI.unescapeHTML(script_content.inner_html) if script_content          
+        content = script_content.inner_html if script_content          
       rescue Nokogiri::XML::SyntaxError => exception
         errors << "Example #{ex[:number]} at line #{ex[:line]} parse error: #{exception.message}"
         $stdout.write "F".colorize(:red)
@@ -451,7 +448,7 @@ ARGV.each do |input|
           $stdout.write "F".colorize(:red)
           next
         end
-        StringIO.new(CGI.unescapeHTML(script_content.inner_html))
+        StringIO.new(script_content.inner_html)
       elsif examples[ex[:result_for]][:ext] == 'html' && ex[:target]
         # Only use the targeted script
         doc = Nokogiri::HTML.parse(examples[ex[:result_for]][:content])
@@ -461,9 +458,7 @@ ARGV.each do |input|
           $stdout.write "F".colorize(:red)
           next
         end
-        StringIO.new(script_content
-          .to_html
-          .gsub(/&lt;/, '<'))
+        StringIO.new(script_content.to_html)
       else
         StringIO.new(examples[ex[:result_for]][:content])
       end

--- a/index.html
+++ b/index.html
@@ -8820,27 +8820,24 @@ the data type to be specified explicitly with each piece of data.</p>
       <a data-cite="HTML52/infrastructure.html#dynamic-changes-to-base-urls">Dynamic changes to base URLs</a>.</p>
   </section>
 
-  <section><h3>Restrictions for contents of JSON-LD <code>script</code> elements</h3>
-    <p class="issue atrisk">This section adds additional requirements for escaping
-      certain JSON values when embedding that JSON within HTML. This approach
-      is consequently subject to further discussion in the Working Group.</p>
-
-    <p>Depending on how the HTML document is served, certain strings may need
-      to be escaped to prevent disrupting the HTML parsing algorithm.</p>
-
+  <section class="informative"><h3>Restrictions for contents of JSON-LD <code>script</code> elements</h3>    
     <p>Due to the HTML <a data-cite="HTML52/semantics-scripting.html#restrictions-for-contents-of-script-elements">Restrictions for contents of <code>&lt;script&gt;</code> elements</a>
       additional encoding restrictions are placed on JSON-LD data contained in
       <a data-cite="HTML52/semantics-scripting.html#the-script-element">script elements</a>.</p>
-    <p>A JSON-LD script element MUST contain only valid JSON.
-      Any strings within the JSON content which contains text which can be confused with a <em>comment-open</em>, <em>script-open</em>,
-      <em>comment-close</em>, or <em>script-close</em> MUST be escaped using <a data-cite="HTML5/syntax.html#character-references">HTML Character references</a>, such as the following:</p>
-    <ul>
-      <li><code>&amp;amp;</code>  → &amp; (<a href="/wiki/Ampersand" title="Ampersand">ampersand</a>, U+0026)</li>
-      <li><code>&amp;lt;</code>   → &lt; (less-than sign, U+003C)</li>
-      <li><code>&amp;gt;</code>   → &gt; (greater-than sign, U+003E)</li>
-      <li><code>&amp;quot;</code> → " (quotation mark, U+0022)</li>
-      <li><code>&amp;apos;</code> → ' (apostrophe, U+0027)</li>
-    </ul>
+    <p>Authors should avoid using character sequences in scripts embedded in HTML
+      which may be confused with a <em>comment-open</em>, <em>script-open</em>,
+      <em>comment-close</em>, or <em>script-close</em>.</p>
+    <div class="note">Such content should be escaped as indicated below, however
+      the content will remain escaped after processing through the
+      JSON-LD API [[JSON-LD11-API]].
+      <ul>
+        <li><code>&amp;amp;</code>  → &amp; (<a href="/wiki/Ampersand" title="Ampersand">ampersand</a>, U+0026)</li>
+        <li><code>&amp;lt;</code>   → &lt; (less-than sign, U+003C)</li>
+        <li><code>&amp;gt;</code>   → &gt; (greater-than sign, U+003E)</li>
+        <li><code>&amp;quot;</code> → " (quotation mark, U+0022)</li>
+        <li><code>&amp;apos;</code> → ' (apostrophe, U+0027)</li>
+      </ul>
+    </div>
 
      <aside class="example ds-selector-tabs"
              title="Embedding JSON-LD containing HTML in HTML">
@@ -8870,7 +8867,7 @@ the data type to be specified explicitly with each piece of data.</p>
         "@type": ["http://schema.org/WebPageElement"],
         "http://schema.org/name": [{"@value": "Encoding Issues"}],
         "http://schema.org/description": [
-          {"@value": "Issues list such as unescaped </script> or - - >"}
+          {"@value": "Issues list such as unescaped &lt;/script&gt; or - -&gt;"}
         ]
       }]
       -->
@@ -8885,7 +8882,7 @@ the data type to be specified explicitly with each piece of data.</p>
 
       [ a schema:WebPageElement;
         schema:name "Encoding Issues";
-        schema:description "Issues list such as unescaped </script> or - - >"
+        schema:description "Issues list such as unescaped &lt;/script&gt; or - -&gt;"
       ] .
       -->
       </pre>


### PR DESCRIPTION
and update examples to not show automatic decoding.

Fixes #100.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/106.html" title="Last updated on Dec 8, 2018, 7:50 PM GMT (b12a965)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/106/28df8b5...b12a965.html" title="Last updated on Dec 8, 2018, 7:50 PM GMT (b12a965)">Diff</a>