### PR TITLE
Added informative reference to SPARQL11-OVERVIEW in intro

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,7 +284,7 @@
   <p>
    JSON-LD is designed to be usable directly as JSON, with no knowledge of RDF
    [[RDF11-CONCEPTS]]. It is also designed to be usable as RDF, if desired, for
-   use with other Linked Data technologies like SPARQL. Developers who
+   use with other Linked Data technologies like SPARQL [[SPARQL11-OVERVIEW]]. Developers who
    require any of the facilities listed above or need to serialize an RDF <a>Graph</a>
    or <a>Dataset</a> in a JSON-based syntax will find JSON-LD of interest. People
    intending to use JSON-LD with RDF tools will find it can be used as another


### PR DESCRIPTION
@gkellogg I'd rather use a PR for the moment, to be sure I don't mess things up.

You'll have to explain to me what magic inserted the correct text for SPARQL11-OVERVIEW in the reference section -- and what would have been required to insert it in the *normative* references instead...