### PR TITLE
Update text on vocabulary mapping and `@vocab` to allow relative IRIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 dist: trusty
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 jobs:
   include:
     - stage: common

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,13 @@
 GIT
   remote: git://github.com/ruby-rdf/json-ld.git
-  revision: a26c3205d006550f85162848a4a2bc3366b39970
+  revision: cee48fd9f71fcf51bca0512d4d8ea36d1d292459
   branch: develop
   specs:
     json-ld (3.0.2)
+      link_header (~> 0.0, >= 0.0.8)
       multi_json (~> 1.13)
-      rdf (~> 3.0, >= 3.0.4)
+      rack (>= 1.6, < 3.0)
+      rdf (~> 3.0, >= 3.0.8)
 
 GEM
   remote: https://rubygems.org/
@@ -16,7 +18,7 @@ GEM
       i18n
     builder (3.2.3)
     colorize (0.8.1)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.4)
     connection_pool (2.2.2)
     ebnf (1.1.3)
       rdf (~> 3.0)
@@ -29,7 +31,7 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     htmlentities (4.3.4)
-    i18n (1.1.1)
+    i18n (1.5.1)
       concurrent-ruby (~> 1.0)
     json-ld-preloaded (3.0.2)
       json-ld (~> 3.0)
@@ -67,17 +69,18 @@ GEM
       shex (~> 0.5, >= 0.5.2)
       sparql (~> 3.0)
       sparql-client (~> 3.0)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     multi_json (1.13.1)
     net-http-persistent (3.0.0)
       connection_pool (~> 2.2)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.0)
+      mini_portile2 (~> 2.4.0)
     nokogumbo (1.5.0)
       nokogiri
     public_suffix (3.0.3)
+    rack (2.0.6)
     rake (12.3.2)
-    rdf (3.0.7)
+    rdf (3.0.9)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
     rdf-aggregate-repo (2.2.1)
@@ -166,4 +169,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/ruby-rdf/json-ld.git
-  revision: cee48fd9f71fcf51bca0512d4d8ea36d1d292459
+  revision: afe7b3b10547b552676d1379a2be4bc34cf83d02
   branch: develop
   specs:
     json-ld (3.0.2)

--- a/index.html
+++ b/index.html
@@ -10757,11 +10757,6 @@ the data type to be specified explicitly with each piece of data.</p>
       may include <code>"@set"</code>, which create maps from the
       graph identifier or index value similar to <a>index maps</a>
       and <a>id maps</a>.</li>
-    <li>a <a>relative IRI</a> has been added as a possible value for <code>@vocab</code> in
-      a context. When this is set, the <a>vocabulary mapping</a> is resolved against
-      the <a>base IRI</a>, so that vocabulary-relative IRIs, such as the
-      keys of <a>node objects</a>, are expanded or compacted relative
-      to the document base.</li>
   </ul>
   <p>Additionally, see <a href="#changes-from-cg" class="sectionRef"></a>.</p>
 </section>
@@ -10776,6 +10771,11 @@ the data type to be specified explicitly with each piece of data.</p>
       with <code>@container</code> set to <code>@set</code>.</li>
     <li>The use of <a>blank node identifiers</a> to label properties is obsolete,
       and may be removed in a future version of JSON-LD, as is the support for <a>generalized RDF Datasets</a>.</li>
+    <li>The <a>default vocabulary</a> can be a relative IRI, which is evaluated
+      either against an existing default vocabulary, or against the document base.
+      This allows vocabulary-relative IRIs, such as the
+      keys of <a>node objects</a>, are expanded or compacted relative
+      to the document base.</li>
   </ul>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -2046,7 +2046,7 @@
     not contain a colon).</p>
 
   <aside class="example ds-selector-tabs"
-         title="Using a common vocabulary prefix">
+         title="Using a default vocabulary">
     <div class="selectors">
       <button class="selected" data-selects="original">Original</button>
       <button data-selects="expanded">Expanded</button>
@@ -2068,7 +2068,7 @@
     -->
     </pre>
     <pre class="expanded nohighlight" data-transform="updateExample"
-         data-result-for="Using a common vocabulary prefix-original">
+         data-result-for="Using a default vocabulary-original">
     <!--
     [{
       "@id": "http://example.org/places#BrewEats",
@@ -2078,7 +2078,7 @@
     -->
     </pre>
     <table class="statements"
-           data-result-for="Using a common vocabulary prefix-expanded"
+           data-result-for="Using a default vocabulary-expanded"
            data-to-rdf>
       <thead><tr><th>Subject</th><th>Property</th><th>Value</th></tr></thead>
       <tbody>
@@ -2088,7 +2088,7 @@
     </table>
     <pre class="turtle"
          data-content-type="text/turtle"
-         data-result-for="Using a common vocabulary prefix-expanded"
+         data-result-for="Using a default vocabulary-expanded"
          data-transform="updateExample"
          data-to-rdf>
     <!--
@@ -2161,15 +2161,80 @@
       schema:name "Brew Eats" .
     -->
     </pre>
+
   </aside>
 
-  <section class="changed">
+  <p class="changed">Since <code>json-ld-1.1</code>,
+    the <a>vocabulary mapping</a> in a <a>local context</a> can be set to the a <a>relative IRI</a>,
+      which is concatentated to any <a>vocabulary mapping</a> in the <a>active context</a>
+      (see <a href="#document-relative-vocabulary-mapping" class="sectionRef"></a>
+      for how this applies if there is no <a>vocabulary mapping</a> in the <a>active context</a>).</p>
+
+  <aside class="example ds-selector-tabs"
+         title="Using a default vocabulary relative to a previous default vocabulary">
+    <div class="selectors">
+      <button class="selected" data-selects="original">Original</button>
+      <button data-selects="expanded">Expanded</button>
+      <button data-selects="statements">Statements</button>
+      <button data-selects="turtle">Turtle</button>
+      <a class="playground" target="_blank"></a>
+    </div>
+    <pre class="original selected nohighlight" data-transform="updateExample">
+    <!--
+    {
+      "@context": [{
+        "@vocab": ****"http://schema.org"****
+      }, ****{
+        "@version": 1.1,
+        "@vocab": "/"
+      }****],
+      "@id": "http://example.org/places#BrewEats",
+      "@type": "Restaurant",
+      "name": "Brew Eats"
+      ####...####
+    }
+    -->
+    </pre>
+    <pre class="expanded nohighlight" data-transform="updateExample"
+         data-result-for="Using a default vocabulary relative to a previous default vocabulary-original">
+    <!--
+    [{
+      "@id": "http://example.org/places#BrewEats",
+      "@type": ["http://schema.org/Restaurant"],
+      "http://schema.org/name": [{"@value": "Brew Eats"}]
+    }]
+    -->
+    </pre>
+    <table class="statements"
+           data-result-for="Using a default vocabulary relative to a previous default vocabulary-expanded"
+           data-to-rdf>
+      <thead><tr><th>Subject</th><th>Property</th><th>Value</th></tr></thead>
+      <tbody>
+        <tr><td>http://example.org/places#BrewEats</td><td>rdf:type</td><td>schema:Restaurant</td></tr>
+        <tr><td>http://example.org/places#BrewEats</td><td>schema:name</td><td>Brew Eats</td></tr>
+      </tbody>
+    </table>
+    <pre class="turtle"
+         data-content-type="text/turtle"
+         data-result-for="Using a default vocabulary relative to a previous default vocabulary-expanded"
+         data-transform="updateExample"
+         data-to-rdf>
+    <!--
+    @prefix schema: <http://schema.org/> .
+
+    <http://example.org/places#BrewEats> a schema:Restaurant;
+      schema:name "Brew Eats" .
+    -->
+    </pre>
+  </aside>
+
+  <section id="document-relative-vocabulary-mapping" class="changed">
     <h3>Using the Document Base for the Default Vocabulary</h3>
     <p>In some cases, vocabulary terms are defined directly within the document
       itself, rather than in an external vocabulary.
-      Since <code>json-ld-1.1</code>, the <a>vocabulary mapping</a> in the <a>active context</a>
-      can be set to the a <a>relative IRI</a>,
-      which is, itself, resolved against the <a>base IRI</a>.
+      Since <code>json-ld-1.1</code>, the <a>vocabulary mapping</a> in a <a>local context</a>
+      can be set to a <a>relative IRI</a>,
+      which is, if there is no vocabulary mapping in scope, resolved against the <a>base IRI</a>.
       This causes terms which are expanded relative to the vocabulary,
       such as the keys of <a>node objects</a>,
       to be based on the <a>base IRI</a> to create <a>absolute IRIs</a>.</p>
@@ -9968,7 +10033,7 @@ the data type to be specified explicitly with each piece of data.</p>
     instead, consider one of the following mechanisms:</p>
   <ul>
     <li>a <a>relative IRI</a>, either relative to the document or the vocabulary
-      (see <a href="#using-the-document-base-for-the-default-vocabulary" class="sectionRef"></a> for a discussion on using the document base as part of the the <a>vocabulary mapping</a>).</li>
+      (see <a href="#document-relative-vocabulary-mapping" class="sectionRef"></a> for a discussion on using the document base as part of the the <a>vocabulary mapping</a>).</li>
     <li>a URN such as <code>urn:example:1</code>, see [[?URN]], or</li>
     <li>a "Skolem IRI" as per
       <a data-cite="RDF11-CONCEPTS#section-skolemization">Replacing Blank Nodes with IRIs</a>

--- a/index.html
+++ b/index.html
@@ -2164,28 +2164,29 @@
   </aside>
 
   <section class="changed">
-    <h3>Using the Document Base as the Default Vocabulary</h3>
+    <h3>Using the Document Base for the Default Vocabulary</h3>
     <p>In some cases, vocabulary terms are defined directly within the document
-      itself, rather than in an external vocabulary. Since
-      <code>json-ld-1.1</code>, the <a>vocabulary mapping</a> in the <a>active
-      context</a> can be set to the empty string <code>&quot;&quot;</code>, which causes terms which
-      are expanded relative to the vocabulary, such as the keys of <a>node
-      objects</a>, to use the <a>base IRI</a> to create <a>absolute
-      IRIs</a>.</p>
+      itself, rather than in an external vocabulary.
+      Since <code>json-ld-1.1</code>, the <a>vocabulary mapping</a> in the <a>active context</a>
+      can be set to the a <a>relative IRI</a>,
+      which is, itself, resolved against the <a>base IRI</a>.
+      This causes terms which are expanded relative to the vocabulary,
+      such as the keys of <a>node objects</a>,
+      to be based on the <a>base IRI</a> to create <a>absolute IRIs</a>.</p>
 
   <pre class="example nohighlight" data-transform="updateExample"
-       title="Using &quot;&quot; as the vocabulary mapping"
+       title="Using &quot;#&quot; as the vocabulary mapping"
        data-base="http://example/document">
   <!--
     {
       "@context": {
         ****"@version": 1.1,****
         ****"@base": "http://example/document",****
-        "@vocab": ****""****
+        "@vocab": ****"#"****
       },
       "@id": "http://example.org/places#BrewEats",
-      "@type": ****"#Restaurant"****,
-      ****"#name"****: "Brew Eats"
+      "@type": ****"Restaurant"****,
+      ****"name"****: "Brew Eats"
       ####...####
     }
   -->
@@ -9658,7 +9659,7 @@ the data type to be specified explicitly with each piece of data.</p>
   <p>If the <a>context definition</a> has an <code>@vocab</code> key,
     its value MUST be a <a>absolute IRI</a>, a <a>compact IRI</a>,
     a <a>blank node identifier</a>,
-    <span class="changed">an empty string (<code>&quot;&quot;</code>)</span>,
+    <span class="changed">a <a>relative IRI</a></span>,
     a <a>term</a>, or <a>null</a>.</p>
 
   <p class="changed">If the <a>context definition</a> has an <code>@version</code> key,
@@ -9916,7 +9917,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <dt><code>@vocab</code></dt><dd>
       The <code>@vocab</code> keyword MUST NOT be aliased and MAY be used as a key in a <a>context definition</a>
       or as the value of <code>@type</code> in an <a>expanded term definition</a>.
-      Its value MUST be a <a>absolute IRI</a>, a <a>compact IRI</a>, a <a>blank node identifier</a>, an empty <a>string</a> (""), a <a>term</a>, or <a>null</a>.
+      Its value MUST be a <a>absolute IRI</a>, <span class="changed">a <a>relative IRI</a></span>, a <a>compact IRI</a>, a <a>blank node identifier</a>, an empty <a>string</a> (""), a <a>term</a>, or <a>null</a>.
       This keyword is described further in <a class="sectionRef" href="#context-definitions"></a>,
       and <a class="sectionRef" href="#default-vocabulary"></a>.
     </dd>
@@ -9967,7 +9968,7 @@ the data type to be specified explicitly with each piece of data.</p>
     instead, consider one of the following mechanisms:</p>
   <ul>
     <li>a <a>relative IRI</a>, either relative to the document or the vocabulary
-      (see <a href="#using-the-document-base-as-the-default-vocabulary" class="sectionRef"></a> for a discussion on using the document base as the <a>vocabulary mapping</a>).</li>
+      (see <a href="#using-the-document-base-for-the-default-vocabulary" class="sectionRef"></a> for a discussion on using the document base as part of the the <a>vocabulary mapping</a>).</li>
     <li>a URN such as <code>urn:example:1</code>, see [[?URN]], or</li>
     <li>a "Skolem IRI" as per
       <a data-cite="RDF11-CONCEPTS#section-skolemization">Replacing Blank Nodes with IRIs</a>
@@ -10691,10 +10692,11 @@ the data type to be specified explicitly with each piece of data.</p>
       may include <code>"@set"</code>, which create maps from the
       graph identifier or index value similar to <a>index maps</a>
       and <a>id maps</a>.</li>
-    <li>The empty string (<code>&quot;&quot;</code>) has been added as a possible value for <code>@vocab</code> in
-      a context. When this is set, vocabulary-relative IRIs, such as the
+    <li>a <a>relative IRI</a> has been added as a possible value for <code>@vocab</code> in
+      a context. When this is set, the <a>vocabulary mapping</a> is resolved against
+      the <a>base IRI</a>, so that vocabulary-relative IRIs, such as the
       keys of <a>node objects</a>, are expanded or compacted relative
-      to the <a>base IRI</a> using string concatenation.</li>
+      to the document base.</li>
   </ul>
   <p>Additionally, see <a href="#changes-from-cg" class="sectionRef"></a>.</p>
 </section>


### PR DESCRIPTION
which are resolved relative to the `base IRI`. This subsumes the previous usage of allowing just the empty string.

This is for #72.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/114.html" title="Last updated on Jan 12, 2019, 10:45 PM UTC (e3dbac5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/114/174c2f9...e3dbac5.html" title="Last updated on Jan 12, 2019, 10:45 PM UTC (e3dbac5)">Diff</a>