### PR TITLE
Proposed description of sealed contexts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/ruby-rdf/json-ld.git
-  revision: afe7b3b10547b552676d1379a2be4bc34cf83d02
+  revision: 6bb0c2d269e8cf80152d519ee5fd16696812b1f2
   branch: develop
   specs:
     json-ld (3.0.2)
@@ -12,7 +12,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     bcp47 (0.3.3)
       i18n
@@ -31,7 +31,7 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     htmlentities (4.3.4)
-    i18n (1.5.1)
+    i18n (1.5.3)
       concurrent-ruby (~> 1.0)
     json-ld-preloaded (3.0.2)
       json-ld (~> 3.0)
@@ -73,14 +73,14 @@ GEM
     multi_json (1.13.1)
     net-http-persistent (3.0.0)
       connection_pool (~> 2.2)
-    nokogiri (1.10.0)
+    nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
     nokogumbo (1.5.0)
       nokogiri
     public_suffix (3.0.3)
     rack (2.0.6)
     rake (12.3.2)
-    rdf (3.0.9)
+    rdf (3.0.10)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
     rdf-aggregate-repo (2.2.1)
@@ -126,7 +126,7 @@ GEM
       rdf-turtle (~> 3.0, >= 3.0.3)
     rdf-trix (2.2.1)
       rdf (>= 2.2, < 4.0)
-    rdf-turtle (3.0.3)
+    rdf-turtle (3.0.5)
       ebnf (~> 1.1)
       rdf (~> 3.0)
     rdf-vocab (3.0.4)

--- a/index.html
+++ b/index.html
@@ -3106,15 +3106,17 @@ specified. The full <a>IRI</a> for
 </section>
 
 <section class="informative changed"><h2>Sealed Contexts</h2>
-  <p>Many JSON-LD contexts are designed to reflect the semantics of a specification,
-    written in prose, and intended for Web developers.
-    It is expected that some implementations of such a specification will rely on JSON-LD and use the context,
-    while other implementations will solely rely on the specification prose.
-    In particular, the latter will ignore embedded and scoped contexts that may locally override the terms defined in the specification.
-    So the interpretation of JSON-LD based implementations, on the one hand,
-    and the interpretation of "prose-based" implementations, on the other hand,
-    may diverge in some situations.
-    To prevent this, JSON-LD 1.1 allows a context to be sealed.
+  <p>JSON-LD is used in many specifications as the specified data format.
+    However, there is also a desire to allow some JSON-LD contents to be processed as plain JSON,
+    without using any of the JSON-LD algorithms.
+    Because JSON-LD is very flexible,
+    some terms from the original format may be locally overridden
+    through the use of embedded contexts,
+    and take a different meaning for JSON-LD based implementations.
+    On the other hand, "plain JSON" implementations may not be able to interpret these embedded contexts,
+    and hence will still interpret those terms with their original meaning.
+    To prevent this divergence of interpretation,
+    JSON-LD 1.1 allows a context to be sealed.
     </p>
   <p>A <dfn>sealed context</dfn> is a context with a member <code>@sealed</code> set to <code>true</code>.
     It prevents further contexts to override its term definitions.

--- a/index.html
+++ b/index.html
@@ -3104,6 +3104,280 @@ specified. The full <a>IRI</a> for
   <p class="note">Scoped Contexts are a new feature in JSON-LD 1.1, requiring
     <a>processing mode</a> set to <code>json-ld-1.1</code>.</p>
 </section>
+
+<section class="informative changed"><h2>Sealed Contexts</h2>
+  <p>Many JSON-LD contexts are designed to reflect the semantics of a specification,
+    written in prose, and intended for Web developers.
+    It is expected that some implementations of such a specification will rely on JSON-LD and use the context,
+    while other implementations will solely rely on the specification prose.
+    In particular, the latter will ignore embedded and scoped contexts that may locally override the terms defined in the specification.
+    So the interpretation of JSON-LD based implementations, on the one hand,
+    and the interpretation of "prose-based" implementations, on the other hand,
+    may diverge in some situations.
+    To prevent this, JSON-LD 1.1 allows a context to be sealed.
+    </p>
+  <p>A <dfn>sealed context</dfn> is a context with a member <code>@sealed</code> set to <code>true</code>.
+    It prevents further contexts to override its term definitions.
+    </p>
+
+
+  <aside class="example ds-selector-tabs changed"
+    title="A sealed @context prevents its term definitions to be overridden">
+    <div class="selectors">
+        <button class="selected" data-selects="original">Original</button>
+        <button data-selects="expanded">Expanded</button>
+        <button data-selects="statements">Statements</button>
+        <button data-selects="turtle">Turtle</button>
+        <a class="playground" target="_blank"></a>
+    </div>
+    <pre class="original selected nohighlight" data-transform="updateExample">
+      <!--
+      {
+        "@context": [
+          {
+            ****"@version": 1.1****,
+            ****"@sealed": true****,
+            "Person": "http://schema.org/Person",
+            "name": "http://schema.org/name",
+            "knows": "http://schema.org/knows"
+          },
+          {
+            ****"Person": "this_attempt_to_override_Person_will_fail"****
+          }
+        ],
+        "@type": "Person",
+        "name": "Manu Sporny",
+        "knows": {
+          "@context": {
+            ****"name": "this_attempt_to_override_name_will_also_fail"****
+          },
+          "name": "Gregg Kellogg"
+        }
+      }
+      -->
+    </pre>
+    <pre class="expanded nohighlight"
+         data-transform="updateExample"
+         data-result-for="A sealed @context prevents its term definitions to be overridden">
+    <!--
+    [{
+      "@type": ["http://schema.org/Person"],
+      "http://schema.org/knows": [
+        {
+          "http://schema.org/name": [{"@value": "Gregg Kellogg"}],
+        }
+      ],
+      "http://schema.org/name": [{"@value": "Manu Sporny"}]
+    }]
+    -->
+    </pre>
+    <table class="statements"
+           data-result-for="A sealed @context prevents its term definitions to be overridden"
+           data-to-rdf>
+      <thead><tr><th>Subject</th><th>Property</th><th>Value</th></tr></thead>
+      <tbody>
+        <tr><td>_:b0</td><td>rdf:type</td><td>schema:Person</td></tr>
+        <tr><td>_:b0</td><td>schema:name</td><td>Manu Sporny</td></tr>
+        <tr><td>_:b0</td><td>schema:knows</td><td>_:b1</td></tr>
+        <tr><td>_:b1</td><td>schema:name</td><td>Gregg Kellogg</td></tr>
+      </tbody>
+    </table>
+    <pre class="turtle"
+         data-content-type="text/turtle"
+         data-result-for="A sealed @context prevents its term definitions to be overridden"
+         data-transform="updateExample"
+         data-to-rdf>
+      <!--
+      @prefix schema: <http://schema.org/> .
+
+      [
+        a schema:Person;
+        schema:name "Manu Sporny";
+        schema:knows [
+          shema:name "Gregg Kellogg"
+        ]
+      ] .
+      -->
+    </pre>
+  </aside>
+
+  <p>Terms defined by a sealed context may still be overridden by scoped contexts,
+    as long as those are defined <em>inside</em> the same sealed context as the original term definition.
+    </p>
+
+  <aside class="example ds-selector-tabs changed"
+    title="A sealed @context can override its own terms">
+    <div class="selectors">
+        <button class="selected" data-selects="original">Original</button>
+        <button data-selects="expanded">Expanded</button>
+        <button data-selects="statements">Statements</button>
+        <button data-selects="turtle">Turtle</button>
+        <a class="playground" target="_blank"></a>
+    </div>
+    <pre class="original selected nohighlight" data-transform="updateExample">
+      <!--
+      {
+        "@context": [
+          {
+            ****"@version": 1.1****,
+            ****"@sealed": true****,
+            "name": "http://schema.org/name",
+            "member": "http://schema.org/member",
+            "Person": {
+              "@id": "http://schema.org/Person",
+              "@context": {
+                "name": "http://schema.org/familyName"
+              }
+            }
+          }
+        ],
+        "name": "Digital Bazaar",
+        "member": {
+          "@type": "Person",
+          "name": "Sporny"
+        }
+      }
+      -->
+    </pre>
+    <pre class="expanded nohighlight"
+         data-transform="updateExample"
+         data-result-for="A sealed @context can override its own terms">
+    <!--
+    [{
+      "@type": ["http://schema.org/Person"],
+      "http://schema.org/name": [{"@value": "Digital Bazaar"}],
+      "http://schema.org/member": [
+        {
+          "http://schema.org/familyame": [{"@value": "Sporny"}],
+        }
+      ],
+    }]
+    -->
+    </pre>
+    <table class="statements"
+           data-result-for="A sealed @context can override its own terms"
+           data-to-rdf>
+      <thead><tr><th>Subject</th><th>Property</th><th>Value</th></tr></thead>
+      <tbody>
+        <tr><td>_:b0</td><td>schema:name</td><td>Digital Bazaar</td></tr>
+        <tr><td>_:b0</td><td>schema:member</td><td>_:b1</td></tr>
+        <tr><td>_:b1</td><td>rdf:type</td><td>schema:Person</td></tr>
+        <tr><td>_:b1</td><td>schema:familyName</td><td>Sporny</td></tr>
+      </tbody>
+    </table>
+    <pre class="turtle"
+         data-content-type="text/turtle"
+         data-result-for="A sealed @context can override its own terms"
+         data-transform="updateExample"
+         data-to-rdf>
+      <!--
+      @prefix schema: <http://schema.org/> .
+
+      [
+        shema:name "Digital Bazaar";
+        schema:member [
+          a schema:Person;
+          schema:familyName "Sporny"
+        ]
+      ] .
+      -->
+    </pre>
+  </aside>
+
+  <p>A sealed context is not necessarily effective in the whole document.
+    Its effect starts in the node where it is referenced or embedded,
+    and propagates to deeper nodes only when traversing terms <em>that it defines</em>.
+    Traversing other terms stops the effect of the sealed context,
+    so in the remaining subtrees of the JSON document,
+    the terms from the sealed context are no longer protected against overridding.
+    The rationale is that "prose-based" implementations would generally ignore any term
+    <em>not</em> defined by the underlying specification,
+    and so the specification does apply to the parts of the documents beyond those unspecified terms.
+    </p>
+
+  <aside class="example ds-selector-tabs changed"
+    title="Sealing does not extend beyond other terms">
+    <div class="selectors">
+        <button class="selected" data-selects="original">Original</button>
+        <button data-selects="expanded">Expanded</button>
+        <button data-selects="statements">Statements</button>
+        <button data-selects="turtle">Turtle</button>
+        <a class="playground" target="_blank"></a>
+    </div>
+    <pre class="original selected nohighlight" data-transform="updateExample">
+      <!--
+      {
+        "@context": [
+          {
+            ****"@version": 1.1****,
+            ****"@sealed": true****,
+            "name": "http://schema.org/name",
+            "Organization": "http://schema.org/Organization"
+          },
+          {
+            "member": "http://xmlns.com/foaf/0.1/member"
+          }
+        ],
+        "@type": "Organization",
+        "name": "Digital Bazzar",
+        "member": {
+          "@context": {
+            "name": "http://xmlns.com/foaf/0.1/name"
+          },
+          "name": "Manu Sporny"
+        }
+      }
+      -->
+    </pre>
+    <pre class="expanded nohighlight"
+         data-transform="updateExample"
+         data-result-for="Sealing does not extend beyond other terms">
+    <!--
+    [{
+      "@type": ["http://schema.org/Organization"],
+      "http://schema.org/name": [{"@value": "Digital Bazaar"}],
+      "http://xmlns.com/foaf/0.1/member": [
+        {
+          "http://xmlns.com/foaf/0.1/name": [{"@value": "Manu Sporny"}],
+        }
+      ],
+    }]
+    -->
+    </pre>
+    <table class="statements"
+           data-result-for="Sealing does not extend beyond other terms"
+           data-to-rdf>
+      <thead><tr><th>Subject</th><th>Property</th><th>Value</th></tr></thead>
+      <tbody>
+        <tr><td>_:b0</td><td>rdf:type</td><td>schema:Organization</td></tr>
+        <tr><td>_:b0</td><td>schema:name</td><td>Digital Bazaar</td></tr>
+        <tr><td>_:b0</td><td>foaf:member</td><td>_:b1</td></tr>
+        <tr><td>_:b1</td><td>foaf:name</td><td>Manu Sporny</td></tr>
+      </tbody>
+    </table>
+    <pre class="turtle"
+         data-content-type="text/turtle"
+         data-result-for="Sealing does not extend beyond other terms"
+         data-transform="updateExample"
+         data-to-rdf>
+      <!--
+      @prefix schema: <http://schema.org/> .
+      @prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+      [
+        a schema:Organization;
+        schema:name "Digital Bazaar";
+        foaf:member [
+          foaf:name "Manu Sporny"
+        ]
+      ] .
+      -->
+    </pre>
+  </aside>
+
+  <p class="note">Sealed Contexts are a new feature in JSON-LD 1.1, requiring
+    <a>processing mode</a> set to <code>json-ld-1.1</code>.</p>
+</section>
 </section>
 
 <section class="informative"><h2>Describing Values</h2>

--- a/index.html
+++ b/index.html
@@ -3160,21 +3160,19 @@ specified. The full <a>IRI</a> for
     </pre>
     <pre class="expanded nohighlight"
          data-transform="updateExample"
-         data-result-for="A sealed @context prevents its term definitions to be overridden">
+         data-result-for="A sealed @context prevents its term definitions to be overridden-original">
     <!--
     [{
       "@type": ["http://schema.org/Person"],
-      "http://schema.org/knows": [
-        {
-          "http://schema.org/name": [{"@value": "Gregg Kellogg"}],
-        }
-      ],
-      "http://schema.org/name": [{"@value": "Manu Sporny"}]
+      "http://schema.org/name": [{"@value": "Manu Sporny"}],
+      "http://schema.org/knows": [{
+        "http://schema.org/name": [{"@value": "Gregg Kellogg"}]
+      }]
     }]
     -->
     </pre>
     <table class="statements"
-           data-result-for="A sealed @context prevents its term definitions to be overridden"
+           data-result-for="A sealed @context prevents its term definitions to be overridden-expanded"
            data-to-rdf>
       <thead><tr><th>Subject</th><th>Property</th><th>Value</th></tr></thead>
       <tbody>
@@ -3186,7 +3184,7 @@ specified. The full <a>IRI</a> for
     </table>
     <pre class="turtle"
          data-content-type="text/turtle"
-         data-result-for="A sealed @context prevents its term definitions to be overridden"
+         data-result-for="A sealed @context prevents its term definitions to be overridden-expanded"
          data-transform="updateExample"
          data-to-rdf>
       <!--
@@ -3196,7 +3194,7 @@ specified. The full <a>IRI</a> for
         a schema:Person;
         schema:name "Manu Sporny";
         schema:knows [
-          shema:name "Gregg Kellogg"
+          schema:name "Gregg Kellogg"
         ]
       ] .
       -->
@@ -3227,9 +3225,10 @@ specified. The full <a>IRI</a> for
             "member": "http://schema.org/member",
             "Person": {
               "@id": "http://schema.org/Person",
-              "@context": {
+              "@context": [null, {
+                "Person": "http://schema.org/Person",
                 "name": "http://schema.org/familyName"
-              }
+              }]
             }
           }
         ],
@@ -3243,21 +3242,21 @@ specified. The full <a>IRI</a> for
     </pre>
     <pre class="expanded nohighlight"
          data-transform="updateExample"
-         data-result-for="A sealed @context can override its own terms">
+         data-result-for="A sealed @context can override its own terms-original">
     <!--
     [{
-      "@type": ["http://schema.org/Person"],
       "http://schema.org/name": [{"@value": "Digital Bazaar"}],
       "http://schema.org/member": [
         {
-          "http://schema.org/familyame": [{"@value": "Sporny"}],
+          "@type": ["http://schema.org/Person"],
+          "http://schema.org/familyName": [{"@value": "Sporny"}]
         }
-      ],
+      ]
     }]
     -->
     </pre>
     <table class="statements"
-           data-result-for="A sealed @context can override its own terms"
+           data-result-for="A sealed @context can override its own terms-expanded"
            data-to-rdf>
       <thead><tr><th>Subject</th><th>Property</th><th>Value</th></tr></thead>
       <tbody>
@@ -3269,14 +3268,14 @@ specified. The full <a>IRI</a> for
     </table>
     <pre class="turtle"
          data-content-type="text/turtle"
-         data-result-for="A sealed @context can override its own terms"
+         data-result-for="A sealed @context can override its own terms-expanded"
          data-transform="updateExample"
          data-to-rdf>
       <!--
       @prefix schema: <http://schema.org/> .
 
       [
-        shema:name "Digital Bazaar";
+        schema:name "Digital Bazaar";
         schema:member [
           a schema:Person;
           schema:familyName "Sporny"
@@ -3325,14 +3324,14 @@ specified. The full <a>IRI</a> for
         "name": "Digital Bazaar",
         "employee" : {
           "@context": {
-            "name": "this_attempt_to_override_name_will_fail"
+            "name": "http://example.org/this_attempt_to_override_name_will_fail"
           },
           "name" : "Dave Longley"
         },
         "member": {
-          "@context": {
+          "@context": [null, {
             "name": "http://xmlns.com/foaf/0.1/name"
-          },
+          }],
           "name": "Manu Sporny"
         }
       }
@@ -3340,14 +3339,14 @@ specified. The full <a>IRI</a> for
     </pre>
     <pre class="expanded nohighlight"
          data-transform="updateExample"
-         data-result-for="Sealing does not extend beyond other terms">
+         data-result-for="Sealing does not extend beyond other terms-original">
     <!--
     [{
       "@type": ["http://schema.org/Organization"],
       "http://schema.org/name": [{"@value": "Digital Bazaar"}],
       "http://schema.org/employee": [
         {
-          "http://schema.org/name": [{"@value": "Dave Longly"}]
+          "http://schema.org/name": [{"@value": "Dave Longley"}]
         }
       ],
       "http://xmlns.com/foaf/0.1/member": [
@@ -3359,7 +3358,7 @@ specified. The full <a>IRI</a> for
     -->
     </pre>
     <table class="statements"
-           data-result-for="Sealing does not extend beyond other terms"
+           data-result-for="Sealing does not extend beyond other terms-expanded"
            data-to-rdf>
       <thead><tr><th>Subject</th><th>Property</th><th>Value</th></tr></thead>
       <tbody>
@@ -3368,12 +3367,12 @@ specified. The full <a>IRI</a> for
         <tr><td>_:b0</td><td>schema:employee</td><td>_:b1</td></tr>
         <tr><td>_:b0</td><td>foaf:member</td><td>_:b2</td></tr>
         <tr><td>_:b1</td><td>schema:name</td><td>Dave Longley</td></tr>
-        <tr><td>_:b1</td><td>foaf:name</td><td>Manu Sporny</td></tr>
+        <tr><td>_:b2</td><td>foaf:name</td><td>Manu Sporny</td></tr>
       </tbody>
     </table>
     <pre class="turtle"
          data-content-type="text/turtle"
-         data-result-for="Sealing does not extend beyond other terms"
+         data-result-for="Sealing does not extend beyond other terms-expanded"
          data-transform="updateExample"
          data-to-rdf>
       <!--
@@ -3382,7 +3381,7 @@ specified. The full <a>IRI</a> for
 
       [
         a schema:Organization;
-        shema:name "Digital Bazaar";
+        schema:name "Digital Bazaar";
         schema:employee [
           schema:name "Dave Longley"
         ];

--- a/index.html
+++ b/index.html
@@ -3388,6 +3388,13 @@ specified. The full <a>IRI</a> for
       -->
     </pre>
   </aside>
+  <p class="note">By preventing terms from being overridden,
+    sealing also prevents any adaptation of a term
+    (e.g., defining a more precise datatype, restricting the term's use to lists, etc.).
+    This kind of adaptation is frequent with some general purpose contexts,
+    for which sealing would therefore hinder their usability.
+    As a consequence, context publishers should use this feature with care.
+    </p>
 
   <p class="note">Sealed term definitions are a new feature in JSON-LD 1.1, requiring
     <a>processing mode</a> set to <code>json-ld-1.1</code>.</p>

--- a/index.html
+++ b/index.html
@@ -3332,9 +3332,9 @@ specified. The full <a>IRI</a> for
         "@type": "Organization",
         "name": "Digital Bazaar",
         "employee" : {
-          #### -- because of "@context": null in the scoped context, ####
-          #### -- the active context at this point is empty; ####
-          #### -- so we can (and we must) redefine "name" below ####
+          #### — because of "@context": null in the scoped context, ####
+          #### — the active context at this point is empty; ####
+          #### — so we can (and we must) redefine "name" below ####
           "@context": {
             ****"name": "http://xmlns.com/foaf/0.1/name"****
           },

--- a/index.html
+++ b/index.html
@@ -3105,7 +3105,7 @@ specified. The full <a>IRI</a> for
     <a>processing mode</a> set to <code>json-ld-1.1</code>.</p>
 </section>
 
-<section class="informative changed"><h2>Sealed Contexts</h2>
+<section class="informative changed"><h2>Sealed Term Definitions</h2>
   <p>JSON-LD is used in many specifications as the specified data format.
     However, there is also a desire to allow some JSON-LD contents to be processed as plain JSON,
     without using any of the JSON-LD algorithms.
@@ -3116,15 +3116,15 @@ specified. The full <a>IRI</a> for
     On the other hand, "plain JSON" implementations may not be able to interpret these embedded contexts,
     and hence will still interpret those terms with their original meaning.
     To prevent this divergence of interpretation,
-    JSON-LD 1.1 allows a context to be sealed.
+    JSON-LD 1.1 allows term definitions to be <em>sealed</em>.
     </p>
-  <p>A <dfn>sealed context</dfn> is a context with a member <code>@sealed</code> set to <code>true</code>.
-    It prevents further contexts to override its term definitions.
+  <p>A <dfn>sealed term definition</dfn> is a term definition with a member <code>@sealed</code> set to <code>true</code>.
+    It prevents further contexts to override this term definition.
     </p>
 
 
   <aside class="example ds-selector-tabs changed"
-    title="A sealed @context prevents its term definitions to be overridden">
+    title="A sealed term definition can not be overridden">
     <div class="selectors">
         <button class="selected" data-selects="original">Original</button>
         <button data-selects="expanded">Expanded</button>
@@ -3138,13 +3138,15 @@ specified. The full <a>IRI</a> for
         "@context": [
           {
             ****"@version": 1.1****,
-            ****"@sealed": true****,
             "Person": "http://schema.org/Person",
-            "name": "http://schema.org/name",
-            "knows": "http://schema.org/knows"
+            "knows": "http://schema.org/knows",
+            "name": {
+              "@id": "http://schema.org/name",
+              ****"@sealed": true****
+            }
           },
           {
-            ****"Person": "this_attempt_to_override_Person_will_fail"****
+            ****"name": "this_attempt_to_override_name_will_fail"****
           }
         ],
         "@type": "Person",
@@ -3160,7 +3162,7 @@ specified. The full <a>IRI</a> for
     </pre>
     <pre class="expanded nohighlight"
          data-transform="updateExample"
-         data-result-for="A sealed @context prevents its term definitions to be overridden-original">
+         data-result-for="A sealed term definition can not be overridden-original">
     <!--
     [{
       "@type": ["http://schema.org/Person"],
@@ -3172,7 +3174,7 @@ specified. The full <a>IRI</a> for
     -->
     </pre>
     <table class="statements"
-           data-result-for="A sealed @context prevents its term definitions to be overridden-expanded"
+           data-result-for="A sealed term definition can not be overridden-expanded"
            data-to-rdf>
       <thead><tr><th>Subject</th><th>Property</th><th>Value</th></tr></thead>
       <tbody>
@@ -3184,7 +3186,7 @@ specified. The full <a>IRI</a> for
     </table>
     <pre class="turtle"
          data-content-type="text/turtle"
-         data-result-for="A sealed @context prevents its term definitions to be overridden-expanded"
+         data-result-for="A sealed term definition can not be overridden-expanded"
          data-transform="updateExample"
          data-to-rdf>
       <!--
@@ -3201,12 +3203,16 @@ specified. The full <a>IRI</a> for
     </pre>
   </aside>
 
-  <p>Terms defined by a sealed context may still be overridden by scoped contexts,
-    as long as those are defined <em>inside</em> the same sealed context as the original term definition.
+  <p>When all or most term definitions of a context need to be sealed,
+    it is possible to add a member <code>@sealed</code> set to <code>true</code>
+    to the context itself.
+    It has the same effect as sealing each of its term definitions individually.
+    Exceptions can be made by adding a member <code>@sealed</code> set to <code>false</code>
+    in some term definitions.
     </p>
 
   <aside class="example ds-selector-tabs changed"
-    title="A sealed @context can override its own terms">
+    title="A sealed @context with an exception">
     <div class="selectors">
         <button class="selected" data-selects="original">Original</button>
         <button data-selects="expanded">Expanded</button>
@@ -3225,79 +3231,76 @@ specified. The full <a>IRI</a> for
             "member": "http://schema.org/member",
             "Person": {
               "@id": "http://schema.org/Person",
-              "@context": [null, {
-                "Person": "http://schema.org/Person",
-                "name": "http://schema.org/familyName"
-              }]
+              ****"@sealed": false****
             }
           }
         ],
         "name": "Digital Bazaar",
         "member": {
+          "@context": {
+            "Person": "http://xmlns.com/foaf/0.1/Person",
+            "name": "this_attempt_to_override_name_will_fail"
+          }
           "@type": "Person",
-          "name": "Sporny"
+          "name": "Manu Sporny"
         }
       }
       -->
     </pre>
     <pre class="expanded nohighlight"
          data-transform="updateExample"
-         data-result-for="A sealed @context can override its own terms-original">
+         data-result-for="A sealed @context with an exception-original">
     <!--
     [{
       "http://schema.org/name": [{"@value": "Digital Bazaar"}],
       "http://schema.org/member": [
         {
-          "@type": ["http://schema.org/Person"],
-          "http://schema.org/familyName": [{"@value": "Sporny"}]
+          "@type": ["http://xmlns.com/foaf/0.1/Person"],
+          "http://schema.org/name": [{"@value": "Manu Sporny"}]
         }
       ]
     }]
     -->
     </pre>
     <table class="statements"
-           data-result-for="A sealed @context can override its own terms-expanded"
+           data-result-for="A sealed @context with an exception-expanded"
            data-to-rdf>
       <thead><tr><th>Subject</th><th>Property</th><th>Value</th></tr></thead>
       <tbody>
         <tr><td>_:b0</td><td>schema:name</td><td>Digital Bazaar</td></tr>
         <tr><td>_:b0</td><td>schema:member</td><td>_:b1</td></tr>
-        <tr><td>_:b1</td><td>rdf:type</td><td>schema:Person</td></tr>
-        <tr><td>_:b1</td><td>schema:familyName</td><td>Sporny</td></tr>
+        <tr><td>_:b1</td><td>rdf:type</td><td>foaf:Person</td></tr>
+        <tr><td>_:b1</td><td>schema:name</td><td>Manu Sporny</td></tr>
       </tbody>
     </table>
     <pre class="turtle"
          data-content-type="text/turtle"
-         data-result-for="A sealed @context can override its own terms-expanded"
+         data-result-for="A sealed @context with an exception-expanded"
          data-transform="updateExample"
          data-to-rdf>
       <!--
+      @prefix foaf: <http://xmlns.com/foaf/0.1/> .
       @prefix schema: <http://schema.org/> .
 
       [
         schema:name "Digital Bazaar";
         schema:member [
-          a schema:Person;
-          schema:familyName "Sporny"
+          a foaf:Person;
+          schema:name "Manu Sporny"
         ]
       ] .
       -->
     </pre>
   </aside>
 
-  <p>A sealed context is not necessarily effective in the whole document.
-    Its effect starts in the node where it is referenced or embedded,
-    and propagates to deeper nodes only when traversing terms <em>that it defines</em>.
-    Traversing other terms stops the effect of the sealed context,
-    so in the remaining subtrees of the JSON document,
-    the terms from the sealed context are no longer protected against overridding.
-    The rationale is that "prose-based" implementations would generally ignore any term
-    <em>not</em> defined by the underlying specification,
-    and so the specification does apply to the parts of the documents beyond those unspecified terms.
-    </p>
+  <p>While sealed term definitions can not be directly overridden,
+      it is worth noting that setting <code>@context</code> to <code>null</code>
+      will erase everything from the active context,
+      <em>including</em> sealed term definitions.
+      </p>
 
   <aside class="example ds-selector-tabs changed"
-    title="Sealing does not extend beyond other terms">
+    title="@context null erases sealed term definitions">
     <div class="selectors">
         <button class="selected" data-selects="original">Original</button>
         <button data-selects="expanded">Expanded</button>
@@ -3312,26 +3315,22 @@ specified. The full <a>IRI</a> for
           {
             ****"@version": 1.1****,
             ****"@sealed": true****,
-            "name": "http://schema.org/name",
-            "employee": "http://schema.org/employee",
             "Organization": "http://schema.org/Organization"
-          },
-          {
-            "member": "http://xmlns.com/foaf/0.1/member"
+            "name": "http://schema.org/name",
+            "employee": {
+              "@id": http://schema.org/employee",
+              ****"@context": null****
           }
         ],
         "@type": "Organization",
         "name": "Digital Bazaar",
         "employee" : {
+          #### -- because of "@context": null in the scoped context, ####
+          #### -- the active context at this point is empty; ####
+          #### -- so we can (and we must) redefine "name" below ####
           "@context": {
-            "name": "http://example.org/this_attempt_to_override_name_will_fail"
+            ****"name": "http://xmlns.com/foaf/0.1/name"****
           },
-          "name" : "Dave Longley"
-        },
-        "member": {
-          "@context": [null, {
-            "name": "http://xmlns.com/foaf/0.1/name"
-          }],
           "name": "Manu Sporny"
         }
       }
@@ -3339,17 +3338,12 @@ specified. The full <a>IRI</a> for
     </pre>
     <pre class="expanded nohighlight"
          data-transform="updateExample"
-         data-result-for="Sealing does not extend beyond other terms-original">
+         data-result-for="@context null erases sealed term definitions-original">
     <!--
     [{
       "@type": ["http://schema.org/Organization"],
       "http://schema.org/name": [{"@value": "Digital Bazaar"}],
       "http://schema.org/employee": [
-        {
-          "http://schema.org/name": [{"@value": "Dave Longley"}]
-        }
-      ],
-      "http://xmlns.com/foaf/0.1/member": [
         {
           "http://xmlns.com/foaf/0.1/name": [{"@value": "Manu Sporny"}]
         }
@@ -3358,34 +3352,29 @@ specified. The full <a>IRI</a> for
     -->
     </pre>
     <table class="statements"
-           data-result-for="Sealing does not extend beyond other terms-expanded"
+           data-result-for="@context null erases sealed term definitions-expanded"
            data-to-rdf>
       <thead><tr><th>Subject</th><th>Property</th><th>Value</th></tr></thead>
       <tbody>
         <tr><td>_:b0</td><td>rdf:type</td><td>schema:Organization</td></tr>
         <tr><td>_:b0</td><td>schema:name</td><td>Digital Bazaar</td></tr>
         <tr><td>_:b0</td><td>schema:employee</td><td>_:b1</td></tr>
-        <tr><td>_:b0</td><td>foaf:member</td><td>_:b2</td></tr>
-        <tr><td>_:b1</td><td>schema:name</td><td>Dave Longley</td></tr>
-        <tr><td>_:b2</td><td>foaf:name</td><td>Manu Sporny</td></tr>
+        <tr><td>_:b1</td><td>foaf:name</td><td>Manu Sporny</td></tr>
       </tbody>
     </table>
     <pre class="turtle"
          data-content-type="text/turtle"
-         data-result-for="Sealing does not extend beyond other terms-expanded"
+         data-result-for="@context null erases sealed term definitions-expanded"
          data-transform="updateExample"
          data-to-rdf>
       <!--
-      @prefix schema: <http://schema.org/>.
       @prefix foaf: <http://xmlns.com/foaf/0.1/>.
+      @prefix schema: <http://schema.org/>.
 
       [
         a schema:Organization;
         schema:name "Digital Bazaar";
         schema:employee [
-          schema:name "Dave Longley"
-        ];
-        foaf:member [
           foaf:name "Manu Sporny"
         ];
       ] .
@@ -3393,7 +3382,7 @@ specified. The full <a>IRI</a> for
     </pre>
   </aside>
 
-  <p class="note">Sealed Contexts are a new feature in JSON-LD 1.1, requiring
+  <p class="note">Sealed term definitions are a new feature in JSON-LD 1.1, requiring
     <a>processing mode</a> set to <code>json-ld-1.1</code>.</p>
 </section>
 </section>

--- a/index.html
+++ b/index.html
@@ -49,8 +49,14 @@
           company:    "Spec-Ops",
           companyURL: "https://spec-ops.io/",
           w3cid:      "44770",
-          note:       "v1.0 and v1.1" }
-        ],
+          note:       "v1.0 and v1.1" },
+        { name:       "Pierre-Antoine Champin",
+          url:        "http://champin.net/",
+          company:    "LIRIS - Université de Lyon",
+          companyURL: "https://liris.cnrs.fr/",
+          w3cid:      "42931",
+          note:       "v1.1" }
+      ],
 
       // editors, add as many as you like
       // only "name" is required

--- a/index.html
+++ b/index.html
@@ -3314,6 +3314,7 @@ specified. The full <a>IRI</a> for
             ****"@version": 1.1****,
             ****"@sealed": true****,
             "name": "http://schema.org/name",
+            "employee": "http://schema.org/employee",
             "Organization": "http://schema.org/Organization"
           },
           {
@@ -3321,7 +3322,13 @@ specified. The full <a>IRI</a> for
           }
         ],
         "@type": "Organization",
-        "name": "Digital Bazzar",
+        "name": "Digital Bazaar",
+        "employee" : {
+          "@context": {
+            "name": "this_attempt_to_override_name_will_fail"
+          },
+          "name" : "Dave Longley"
+        },
         "member": {
           "@context": {
             "name": "http://xmlns.com/foaf/0.1/name"
@@ -3338,11 +3345,16 @@ specified. The full <a>IRI</a> for
     [{
       "@type": ["http://schema.org/Organization"],
       "http://schema.org/name": [{"@value": "Digital Bazaar"}],
-      "http://xmlns.com/foaf/0.1/member": [
+      "http://schema.org/employee": [
         {
-          "http://xmlns.com/foaf/0.1/name": [{"@value": "Manu Sporny"}],
+          "http://schema.org/name": [{"@value": "Dave Longly"}]
         }
       ],
+      "http://xmlns.com/foaf/0.1/member": [
+        {
+          "http://xmlns.com/foaf/0.1/name": [{"@value": "Manu Sporny"}]
+        }
+      ]
     }]
     -->
     </pre>
@@ -3353,7 +3365,9 @@ specified. The full <a>IRI</a> for
       <tbody>
         <tr><td>_:b0</td><td>rdf:type</td><td>schema:Organization</td></tr>
         <tr><td>_:b0</td><td>schema:name</td><td>Digital Bazaar</td></tr>
-        <tr><td>_:b0</td><td>foaf:member</td><td>_:b1</td></tr>
+        <tr><td>_:b0</td><td>schema:employee</td><td>_:b1</td></tr>
+        <tr><td>_:b0</td><td>foaf:member</td><td>_:b2</td></tr>
+        <tr><td>_:b1</td><td>schema:name</td><td>Dave Longley</td></tr>
         <tr><td>_:b1</td><td>foaf:name</td><td>Manu Sporny</td></tr>
       </tbody>
     </table>
@@ -3363,15 +3377,18 @@ specified. The full <a>IRI</a> for
          data-transform="updateExample"
          data-to-rdf>
       <!--
-      @prefix schema: <http://schema.org/> .
+      @prefix schema: <http://schema.org/>.
       @prefix foaf: <http://xmlns.com/foaf/0.1/>.
 
       [
         a schema:Organization;
-        schema:name "Digital Bazaar";
+        shema:name "Digital Bazaar";
+        schema:employee [
+          schema:name "Dave Longley"
+        ];
         foaf:member [
           foaf:name "Manu Sporny"
-        ]
+        ];
       ] .
       -->
     </pre>

--- a/index.html
+++ b/index.html
@@ -3246,7 +3246,7 @@ specified. The full <a>IRI</a> for
           "@context": {
             "Person": "http://xmlns.com/foaf/0.1/Person",
             "name": "this_attempt_to_override_name_will_fail"
-          }
+          },
           "@type": "Person",
           "name": "Manu Sporny"
         }
@@ -3321,11 +3321,12 @@ specified. The full <a>IRI</a> for
           {
             ****"@version": 1.1****,
             ****"@sealed": true****,
-            "Organization": "http://schema.org/Organization"
+            "Organization": "http://schema.org/Organization",
             "name": "http://schema.org/name",
             "employee": {
-              "@id": http://schema.org/employee",
+              "@id": "http://schema.org/employee",
               ****"@context": null****
+            }
           }
         ],
         "@type": "Organization",


### PR DESCRIPTION
As per my action during last call, here is a first proposal to describe sealed contexts in the Syntax document. A few comments about this text:

* After writing this, I take back what I said about multiple sealed contexts; I think it can work. I'm still not comfortable with sealing individual terms, though (and the algorithm that I am about the propose does not handle them). However I chose not to mention them in this non-normative section, to keep it short enough.

* Resetting `@context` to `null` must also be prevented by sealed contexts, since it resets *all* term definitions. I didn't mention that in the text, though, because the effect of setting `@context` to null is never described in the document (it is in the API doc).

* Finally, I didn't mention "extension points" in sealed contexts (i.e. terms of a sealed context that explicit reset the context and hence stop the sealing).

* The first example in the "Sealed contexts" section will actually fail(?) and thus provide no result. So may be the alternative versions should not even be included??


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/119.html" title="Last updated on Feb 13, 2019, 6:18 PM UTC (876c194)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/119/1533ca9...876c194.html" title="Last updated on Feb 13, 2019, 6:18 PM UTC (876c194)">Diff</a>