### PR TITLE
Clarify compact IRI term example

### DIFF
--- a/index.html
+++ b/index.html
@@ -2816,8 +2816,8 @@
     ****"foaf": "http://xmlns.com/foaf/0.1/"****,
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "name": "foaf:name",
-    "age": {
-      "@id": "foaf:age",
+    ""****foaf:age"****": {
+      "@id": "****http://xmlns.com/foaf/0.1/age****",
       "@type": "xsd:integer"
     },
     "****foaf:homepage****": ****{

--- a/index.html
+++ b/index.html
@@ -2816,7 +2816,8 @@
     ****"foaf": "http://xmlns.com/foaf/0.1/"****,
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "name": "foaf:name",
-    "****foaf:age****": {
+    "age": {
+      "@id": "foaf:age",
       "@type": "xsd:integer"
     },
     "****foaf:homepage****": ****{

--- a/index.html
+++ b/index.html
@@ -2855,7 +2855,7 @@ specified. The full <a>IRI</a> for
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "name": "foaf:name",
     "foaf:age": {
-      "@id": "foaf:age",
+      "@id": "http://xmlns.com/foaf/0.1/age",
       "@type": "xsd:integer"
     },
     "****http://xmlns.com/foaf/0.1/homepage****": {

--- a/index.html
+++ b/index.html
@@ -2816,7 +2816,7 @@
     ****"foaf": "http://xmlns.com/foaf/0.1/"****,
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "name": "foaf:name",
-    ""****foaf:age"****": {
+    "****foaf:age****": {
       "@id": "****http://xmlns.com/foaf/0.1/age****",
       "@type": "xsd:integer"
     },


### PR DESCRIPTION
Make example 36 "Using a compact IRI as a term" clearer, but only defining `foaf:homepage` using the compact IRI term form.

Fixes #123.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/126.html" title="Last updated on Feb 12, 2019, 11:22 PM UTC (bc3a64c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/126/1533ca9...bc3a64c.html" title="Last updated on Feb 12, 2019, 11:22 PM UTC (bc3a64c)">Diff</a>