### PR TITLE
Better phrasing of object equality

### DIFF
--- a/index.html
+++ b/index.html
@@ -11409,8 +11409,12 @@ the data type to be specified explicitly with each piece of data.</p>
           <li>If <var>A</var> and <var>B</var> are both <a>objects</a>,
             both <var>A</var> and <var>B</var> have the same number of <a>members</a>,
             and each <a>member</a> in <var>A</var> is equal to a corresponding <a>member</a> in <var>B</var>
-            where the keys are identical, and the values are considered equal through
-            applying this comparison recursively.</li>
+            where <ul>
+              <li>the keys are equal (as defined in <a data-cite="ECMASCRIPT#sec-samevaluenonnumber">Section 7.2.12, step 5.a</a>
+                  in [[ECMASCRIPT]]), and</li>
+              <li>the values are considered equal through
+                applying this comparison recursively.</li>
+            </ul>
           <li>Otherwise, if <var>A</var> and <var>B</var> are both <a>arrays</a>,
             both <var>A</var> and <var>B</var> have the same number of elements,
             and each element <var>A<sub>i</sub></var> is considered

--- a/index.html
+++ b/index.html
@@ -11408,7 +11408,7 @@ the data type to be specified explicitly with each piece of data.</p>
         <ol>
           <li>If <var>A</var> and <var>B</var> are both <a>objects</a>,
             both <var>A</var> and <var>B</var> have the same number of <a>members</a>,
-            a <a>member</a> in <var>A</var> is equal to a corresponding <a>member</a> in <var>B</var>
+            and each <a>member</a> in <var>A</var> is equal to a corresponding <a>member</a> in <var>B</var>
             where the keys are identical, and the values are considered equal through
             applying this comparison recursively.</li>
           <li>Otherwise, if <var>A</var> and <var>B</var> are both <a>arrays</a>,


### PR DESCRIPTION
I think the current phrasing is actually inaccurate. It seemed to imply (at least to me, a non-native speaker) that *one* equal member was enough for the objects to be considered equal.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/152.html" title="Last updated on Mar 27, 2019, 4:54 PM UTC (36ece32)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/152/1e85d7a...36ece32.html" title="Last updated on Mar 27, 2019, 4:54 PM UTC (36ece32)">Diff</a>