### PR TITLE
Correct term assignment to proper IRI in example 42.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3306,14 +3306,14 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
         "Type1": {
           "@id": "http://example.com/vocab/Type1",
           "@context": {
-            "term2": "http://example.com/vocab/term3"
+            "term3": "http://example.com/vocab/term3"
             #### ↑ Scoped context for "Type1" defines term3
           },
         },
         "Type2": {
           "@id": "http://example.com/vocab/Type2",
           "@context": {
-            "term3": "http://example.com/vocab/term4"
+            "term4": "http://example.com/vocab/term4"
             #### ↑ Scoped context for "Type2" defines term4
           },
         },


### PR DESCRIPTION
This correction is for example 42 regarding scoped contexts:

```
{
  "@context": {
    "@vocab": "http://example.com/vocab/"
    "property": {
      "@id": "http://example.com/vocab/property",
      "@context": {
        "term1": "http://example.com/vocab/term1"
         ↑ Scoped context for "property" defines term1
      },
    },
    "Type1": {
      "@id": "http://example.com/vocab/Type1",
      "@context": {
        "term2": "http://example.com/vocab/term3"
         ↑ Scoped context for "Type1" defines term3
      },
    },
    "Type2": {
      "@id": "http://example.com/vocab/Type2",
      "@context": {
        "term3": "http://example.com/vocab/term4"
         ↑ Scoped context for "Type2" defines term4
      },
    },
  },
  "property": {
    "@context": {
      "term2": "http://example.com/vocab/term2"
         ↑ Embedded context defines term2
    },
    "@type": ["Type2", "Type1"],
    "term1": "a",
    "term2": "b",
    "term3": "c",
    "term4": "d",
  }
}
```
I am not sure if the point of this example is that term2 can refer to a different IRI in 2 different scoped contexts, however both the IRI for the first declaration of term2 and term3 both point at iris that don't coincide with their name.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aljones15/json-ld-syntax/pull/173.html" title="Last updated on May 7, 2019, 2:14 AM UTC (7c78d39)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/173/67d8926...aljones15:7c78d39.html" title="Last updated on May 7, 2019, 2:14 AM UTC (7c78d39)">Diff</a>