### PR TITLE
Be more clear about literals as value objects

### DIFF
--- a/common/terms.html
+++ b/common/terms.html
@@ -226,7 +226,7 @@
     A <a>list object</a> is a <a>dictionary</a> that has a <code>@list</code> key.
     It may also have an <code>@index</code> key, but no other members.</dd>
   <dt><dfn>literal</dfn></dt><dd>
-    An <a>object</a> expressed as a value such as a string, number or in expanded form.</dd>
+    An <a>object</a> expressed as a value such as a string, number or in expanded form as a <a>value object</a>.</dd>
   <dt><dfn>local context</dfn></dt><dd>
     A <a>context</a> that is specified with a <a>dictionary</a>,
     specified via the <code>@context</code> <a>keyword</a>.</dd>

--- a/common/terms.html
+++ b/common/terms.html
@@ -226,7 +226,7 @@
     A <a>list object</a> is a <a>dictionary</a> that has a <code>@list</code> key.
     It may also have an <code>@index</code> key, but no other members.</dd>
   <dt><dfn>literal</dfn></dt><dd>
-    An <a>object</a> expressed as a value such as a string, number or in expanded form as a <a>value object</a>.</dd>
+    An <a>object</a> expressed as a value such as a string or number, or in expanded form as a <a>value object</a>.</dd>
   <dt><dfn>local context</dfn></dt><dd>
     A <a>context</a> that is specified with a <a>dictionary</a>,
     specified via the <code>@context</code> <a>keyword</a>.</dd>


### PR DESCRIPTION
It wasn't a typo, but could be more complete.

"An object expressed as a value such as a string, number or in expanded form **as a value object**."

cc/@kasei

Fixes #176.