### PR TITLE
Update example label styling (for contexts, etc.) and invert tabs for example 26/27

### DIFF
--- a/index.html
+++ b/index.html
@@ -2449,7 +2449,7 @@
   <aside class="example ds-selector-tabs"
          title="Using &quot;#&quot; as the vocabulary mapping">
     <div class="selectors">
-      <button class="selected" data-selects="compacted">Compacted</button>
+      <button class="selected" data-selects="compacted">Compacted (Input)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
       <a class="playground" target="_blank"></a>

--- a/index.html
+++ b/index.html
@@ -2449,12 +2449,12 @@
   <aside class="example ds-selector-tabs"
          title="Using &quot;#&quot; as the vocabulary mapping">
     <div class="selectors">
-      <button class="selected" data-selects="original">Original</button>
+      <button class="selected" data-selects="compacted">Compacted</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
       <a class="playground" target="_blank"></a>
     </div>
-    <pre class="original selected nohighlight" data-transform="updateExample"
+    <pre class="compacted selected nohighlight" data-transform="updateExample"
          title="Using &quot;#&quot; as the vocabulary mapping"
          data-base="http://example/document">
     <!--
@@ -2472,7 +2472,7 @@
     -->
     </pre>
     <table class="statements"
-           data-result-for="Using &quot;#&quot; as the vocabulary mapping-original"
+           data-result-for="Using &quot;#&quot; as the vocabulary mapping-compacted"
            data-to-rdf>
       <thead><tr><th>Subject</th><th>Property</th><th>Value</th></tr></thead>
       <tbody>
@@ -2482,7 +2482,7 @@
     </table>
     <pre class="turtle"
          data-content-type="text/turtle"
-         data-result-for="Using &quot;#&quot; as the vocabulary mapping-original"
+         data-result-for="Using &quot;#&quot; as the vocabulary mapping-compacted"
          data-transform="updateExample"
          data-to-rdf>
     <!--
@@ -2496,6 +2496,7 @@
 
   <pre class="example expanded nohighlight"
        data-transform="updateExample"
+       data-result-for="Using &quot;#&quot; as the vocabulary mapping-compacted"
        title="Using &quot;#&quot; as the vocabulary mapping (expanded)">
   <!--
   [{

--- a/index.html
+++ b/index.html
@@ -144,18 +144,24 @@
     float: right;
     font: x-large Arial, sans-serif;
     color: gray;
+    border: solid thin black;
+    padding: 0.2em;
   }
   .example > pre.frame:before {
     content: "Frame";
     float: right;
     font: x-large Arial, sans-serif;
     color: gray;
+    border: solid thin black;
+    padding: 0.2em;
   }
   .example > pre.input:before {
     content: "Input";
     float: right;
     font: x-large Arial, sans-serif;
     color: gray;
+    border: solid thin black;
+    padding: 0.2em;
   }
   .changed {
     background-color: rgb(215, 238, 197);
@@ -2440,45 +2446,33 @@
       such as the keys of <a>node objects</a>,
       to be based on the <a>base IRI</a> to create <a>absolute IRIs</a>.</p>
 
-  <pre class="example nohighlight" data-transform="updateExample"
-       title="Using &quot;#&quot; as the vocabulary mapping"
-       data-base="http://example/document">
-  <!--
-    {
-      "@context": {
-        ****"@version": 1.1,****
-        ****"@base": "http://example/document",****
-        "@vocab": ****"#"****
-      },
-      "@id": "http://example.org/places#BrewEats",
-      "@type": ****"Restaurant"****,
-      ****"name"****: "Brew Eats"
-      ####...####
-    }
-  -->
-  </pre>
-
-  <p>If this document were located at <code>http://example/document</code>, it would expand as follows:</p>
-
   <aside class="example ds-selector-tabs"
-         title="Using &quot;#&quot; as the vocabulary mapping (expanded)">
+         title="Using &quot;#&quot; as the vocabulary mapping">
     <div class="selectors">
-      <button class="selected" data-selects="expanded">Expanded</button>
+      <button class="selected" data-selects="original">Original</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
       <a class="playground" target="_blank"></a>
     </div>
-    <pre class="expanded selected nohighlight" data-transform="updateExample">
+    <pre class="original selected nohighlight" data-transform="updateExample"
+         title="Using &quot;#&quot; as the vocabulary mapping"
+         data-base="http://example/document">
     <!--
-    [{
-      "@id": "http://example.org/places#BrewEats",
-      "@type": ["http://example/document#Restaurant"],
-      "http://example/document#name": [{"@value": "Brew Eats"}]
-    }]
+      {
+        "@context": {
+          ****"@version": 1.1,****
+          ****"@base": "http://example/document",****
+          "@vocab": ****"#"****
+        },
+        "@id": "http://example.org/places#BrewEats",
+        "@type": ****"Restaurant"****,
+        ****"name"****: "Brew Eats"
+        ####...####
+      }
     -->
     </pre>
     <table class="statements"
-           data-result-for="Using &quot;#&quot; as the vocabulary mapping (expanded)-expanded"
+           data-result-for="Using &quot;#&quot; as the vocabulary mapping-original"
            data-to-rdf>
       <thead><tr><th>Subject</th><th>Property</th><th>Value</th></tr></thead>
       <tbody>
@@ -2488,7 +2482,7 @@
     </table>
     <pre class="turtle"
          data-content-type="text/turtle"
-         data-result-for="Using &quot;#&quot; as the vocabulary mapping (expanded)-expanded"
+         data-result-for="Using &quot;#&quot; as the vocabulary mapping-original"
          data-transform="updateExample"
          data-to-rdf>
     <!--
@@ -2497,6 +2491,20 @@
     -->
     </pre>
   </aside>
+
+  <p>If this document were located at <code>http://example/document</code>, it would expand as follows:</p>
+
+  <pre class="example expanded nohighlight"
+       data-transform="updateExample"
+       title="Using &quot;#&quot; as the vocabulary mapping (expanded)">
+  <!--
+  [{
+    "@id": "http://example.org/places#BrewEats",
+    "@type": ["http://example/document#Restaurant"],
+    "http://example/document#name": [{"@value": "Brew Eats"}]
+  }]
+  -->
+  </pre>
   </section>
 </section>
 


### PR DESCRIPTION
Fixes #178.

If this is acceptable, will apply stying changes to API and Framing docs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/188.html" title="Last updated on May 27, 2019, 6:51 PM UTC (22d0b4f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/188/a3a0224...22d0b4f.html" title="Last updated on May 27, 2019, 6:51 PM UTC (22d0b4f)">Diff</a>