### PR TITLE
Add version list of lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -5352,6 +5352,7 @@ the data type to be specified explicitly with each piece of data.</p>
        data-transform="updateExample">
   {
     "@context": {
+      "@version": 1.1,
       "@vocab": "https://purl.org/geojson/vocab#",
       "type": "@type",
       "bbox": {"@container": "@list"},


### PR DESCRIPTION
Example 71 for recursive lists is a feature on version 1.1.
so added a version tag to the example.

```
"@context": {
      "@version": 1.1,
      "@vocab": "https://purl.org/geojson/vocab#"
}
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aljones15/json-ld-syntax/pull/194.html" title="Last updated on Jun 14, 2019, 11:50 PM UTC (8ea845d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/194/16c60eb...aljones15:8ea845d.html" title="Last updated on Jun 14, 2019, 11:50 PM UTC (8ea845d)">Diff</a>