### PR TITLE
Describe that type-scoped contexts are only in affect on the node objects in which they're used

### DIFF
--- a/index.html
+++ b/index.html
@@ -3410,6 +3410,9 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     the type is used; the previous in-scope <a>contexts</a> are placed back into
     effect when traversing into another <a>node object</a>.</p>
 
+  <p class="note">Any property-scoped or local contexts that were introduced in the <a>node object</a>
+    would still be in effect when traversing into another <a>node object</a>.</p>
+
   <p>When expanding, each value of <code>@type</code> is considered
     (ordering them lexicographically) where that value is also a <a>term</a> in
     the <a>active context</a> having its own <a>scoped context</a>. If so, that

--- a/index.html
+++ b/index.html
@@ -3405,7 +3405,10 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     relate things of different types, where the vocabularies in use within
     different entities calls for different context scoping. For example,
     <code>hasPart</code>/<code>partOf</code> may be common terms used in a document, but mean
-    different things depending on the context.</p>
+    different things depending on the context.
+    A <a>context</a> scoped on <code>@type</code> is only in effect for the <a>node object</a> on which
+    the type is used; the previous in-scope <a>contexts</a> are placed back into
+    effect when traversing into another <a>node object</a>.</p>
 
   <p>When expanding, each value of <code>@type</code> is considered
     (ordering them lexicographically) where that value is also a <a>term</a> in
@@ -12835,6 +12838,8 @@ the data type to be specified explicitly with each piece of data.</p>
       using type <code>application/ld+json;profile=http://www.w3.org/ns/json-ld#frame</code>.</li>
     <li>Term definitions can now be <a href="#protected-term-definitions">protected</a>,
       to limit the ability of other contexts to override them.</li>
+    <li>A <a>context</a> defined in an <a>expanded term definition</a> may also be used for values
+      of <code>@type</code>, which defines a <a>context</a> to use for <a>node objects</a> including the associated type.</li>
   </ul>
 </section>
 


### PR DESCRIPTION
Add changes for type-scoped contexts.

Fixes #174.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/195.html" title="Last updated on Jun 19, 2019, 11:14 PM UTC (08b3a1c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/195/16c60eb...08b3a1c.html" title="Last updated on Jun 19, 2019, 11:14 PM UTC (08b3a1c)">Diff</a>