### PR TITLE
Respec updates

### DIFF
--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -13,7 +13,7 @@
     A flag specifying that for <a>properties</a> to be included in the output,
     they MUST be explicitly declared in the matching <a>frame</a>.</dd>
   <dt><dfn>framing state</dfn></dt><dd>
-    A <a>dictionary</a> containing values for the
+    A <a>map</a> containing values for the
     <a>object embed flag</a>, the
     <a>require all flag</a>, the
     <a>explicit inclusion flag</a>, and the
@@ -35,7 +35,7 @@
     but present in the <a>input frame</a>,
     should be omitted from the output.</dd>
   <dt class="changed"><dfn>omit graph flag</dfn></dt><dd class="changed">
-    A flag that determines if framing output is always contained within a <code>@graph</code> member,
+    A flag that determines if framing output is always contained within a <code>@graph</code> <a>entry</a>,
     or only if required to represent multiple <a>node objects</a>.</dd>
   <dt><dfn>processor state</dfn></dt><dd>
     The <a>processor state</a>,

--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -42,8 +42,8 @@
     which includes the <a>active context</a>, <a>active subject</a>, and <a>active property</a>.
     The <a>processor state</a> is managed as a stack with elements from the previous <a>processor state</a>
     copied into a new <a>processor state</a> when entering a new <a>JSON object</a>.</dd>
-  <dt><dfn>promise</dfn></dt><dd>
-    A <a data-cite="ECMASCRIPT#sec-promise-objects" class="externalDFN">promise</a> is an object that represents the eventual result of a single asynchronous operation.
+  <dt><dfn data-cite="ECMASCRIPT#sec-promise-objects">promise</dfn></dt><dd>
+    A <a>promise</a> is an object that represents the eventual result of a single asynchronous operation.
     Promises are defined in [[ECMASCRIPT]].</dd>
   <dt><dfn>require all flag</dfn></dt><dd>
     A flag specifying that all properties present in the <a>input frame</a>

--- a/common/common.js
+++ b/common/common.js
@@ -23,7 +23,7 @@ function restrictReferences(utils, content) {
   // remove any terms they reference from the termNames array too.
   const noPreserve = base.querySelectorAll("dfn:not(.preserve)");
   for (const item of noPreserve) {
-    const $t = $(item) ;
+    const $t = $(item);
     const titles = $t.getDfnTitles();
     const n = $t.makeID("dfn", titles[0]);
     if (n) {
@@ -34,6 +34,20 @@ function restrictReferences(utils, content) {
   const $container = $(".termlist", base) ;
   const containerID = $container.makeID("", "terms") ;
   termLists.push(containerID) ;
+  return (base.innerHTML);
+}
+
+// Mark definitions to be exported
+function exportReferences(utils, content) {
+  const base = document.createElement("div");
+  base.innerHTML = content;
+
+  const defns = base.querySelectorAll("dfn:not([data-cite])");
+  for (const item of defns) {
+    const de = document.createAttribute("data-export");
+    item.setAttributeNode(de);
+  }
+
   return (base.innerHTML);
 }
 

--- a/common/terms.html
+++ b/common/terms.html
@@ -1,5 +1,5 @@
 <dl class="termlist" data-sort>
-  <dt><dfn>array</dfn></dt><dd>
+  <dt><dfn data-cite="ECMASCRIPT#sec-array-objects">array</dfn></dt><dd>
     In the JSON serialization,
     an array structure is represented as square brackets surrounding zero or more values.
     Values are separated by commas.
@@ -9,11 +9,11 @@
     the collection is <em>unordered</em> by default.
     While order is preserved in regular JSON arrays,
     it is not in regular JSON-LD arrays unless specifically defined
-    (see <a data-cite="JSON-LD11#sets-and-lists" class="externalDFN">Sets and Lists</a>
+    (see <a data-cite="JSON-LD11#sets-and-lists">Sets and Lists</a>
     in the JSON-LD Syntax specification [[JSON-LD11]]).</dd>
-  <dt><dfn>JSON object</dfn></dt><dd>
+  <dt><dfn data-cite="RFC8259#section-4">JSON object</dfn></dt><dd>
     In the JSON serialization,
-    an <a data-cite="RFC8259#section-4" class="externalDFN">object</a> structure
+    an <a>object</a> structure
     is represented as a pair of curly brackets surrounding zero or more members
     composed of name-value pairs.
     A name is a <a>string</a>.
@@ -21,7 +21,7 @@
     separating the name from the value.
     A single comma separates a value from a following name.
     In JSON-LD the names in an object MUST be unique.
-    In the <a>internal representation</a> a <a>JSON object</a> is equivalent to a
+    In the <a>internal representation</a> a <a>JSON object</a> is described as a
     <dfn data-cite="WEBIDL#dfn-dictionary" class="preserve">dictionary</dfn> (see [[WEBIDL]]),
     composed of <dfn data-cite="WEBIDL#dfn-dictionary-member" data-lt="dictionary member|member" class="preserve">dictionary members</dfn> with key-value pairs.</dd>
   <dt class="changed"><dfn data-lt="internal representation">JSON-LD internal representation</dfn></dt><dd class="changed">
@@ -29,8 +29,8 @@
     is the result of transforming a JSON syntactic structure
     into the core data structures suitable for direct processing:
     <a>arrays</a>, <a>dictionaries</a>, <a>strings</a>, <a>numbers</a>, <a>booleans</a>, and <a>null</a>.</dd>
-  <dt><dfn>null</dfn></dt><dd>
-    The use of the <a data-cite="RFC8259#section-3" class="externalDFN">null</a> value within JSON-LD
+  <dt><dfn data-cite="ECMASCRIPT#sec-null-value">null</dfn></dt><dd>
+    The use of the <a data-cite="RFC8259#section-3">null</a> value within JSON-LD
     is used to ignore or reset values.
     A <a>dictionary member</a> in the <code>@context</code> where the value,
     or the <code>@id</code> of the value, is <code>null</code>,
@@ -40,49 +40,49 @@
     has the same meaning as if the <a>dictionary member</a> was not defined.
     If <code>@value</code>, <code>@list</code>, or <code>@set</code> is set to <code>null</code> in expanded form,
     then the entire <a>JSON object</a> is ignored.</dd>
-  <dt><dfn data-lt="number|JSON number">number</dfn></dt><dd>
-    In the JSON serialization, a <a data-cite="RFC8259#section-6" class="externalDFN">number</a>
+  <dt><dfn data-cite="ECMASCRIPT#sec-terms-and-definitions-number-value" data-lt="number|JSON number">number</dfn></dt><dd>
+    In the JSON serialization, a <a>number</a>
     is similar to that used in most programming languages,
     except that the octal and hexadecimal formats are not used and that leading zeros are not allowed.
     In the <a>internal representation</a>,
     a <a>number</a> is equivalent to either a <dfn data-cite="WEBIDL#idl-long" class="preserve">long</dfn>
     or <dfn data-cite="WEBIDL#idl-double" class="preserve">double</dfn>,
     depending on if the number has a non-zero fractional part (see [[WEBIDL]]).</dd>
-  <dt><dfn>scalar</dfn></dt><dd>
-    A scalar is either a JSON <a>string</a>, <a>number</a>, <a>true</a>, or <a>false</a>.</dd>
-  <dt><dfn>string</dfn></dt><dd>
-    A <a data-cite="RFC8259#section-7" class="externalDFN">string</a>
+  <dt><dfn data-cite="#sec-primitive-value" data-no-xref="">scalar</dfn></dt><dd>
+    A scalar is either a JSON <a>string</a>, <a>number</a>, <code>true</code>, or <code>false</code>.</dd>
+  <dt><dfn data-cite="ECMASCRIPT#sec-terms-and-definitions-string-value">string</dfn></dt><dd>
+    A <a>string</a>
     is a sequence of zero or more Unicode (UTF-8) characters,
     wrapped in double quotes, using backslash escapes (if necessary).
     A character is represented as a single character string.</dd>
-  <dt><dfn>true</dfn> and <dfn>false</dfn></dt><dd>
-    <a data-cite="RFC8259#section-3" class="externalDFN">Values</a> that are used
-    to express one of two possible <dfn data-cite="WEBIDL#idl-boolean" class="preserve">boolean</dfn> states.</dd>
+  <dt><dfn data-cite="ECMASCRIPT#sec-terms-and-definitions-boolean-value">boolean</dfn></dt><dd>
+    The values <code>true</code> and <code>false</code> that are used
+    to express one of two possible states.</dd>
 </dl>
 
 <p>Furthermore, the following terminology is used throughout this document:</p>
 
 <dl class="termlist" data-sort>
-  <dt><dfn>absolute IRI</dfn></dt><dd>
-    An <a data-cite="RFC3987#section-1.3" class="externalDFN">absolute IRI</a>
+  <dt><dfn data-cite="RFC3987#section-1.3">absolute IRI</dfn></dt><dd>
+    An <a>absolute IRI</a>
     is defined in [[RFC3987]] containing a <em>scheme</em> along with a <em>path</em>
     and optional <em>query</em> and fragment segments.</dd>
   <dt><dfn>active context</dfn></dt><dd>
     A <a>context</a> that is used to resolve <a>terms</a>
     while the processing algorithm is running.</dd>
-  <dt><dfn>base IRI</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-base-iri">base IRI</dfn></dt><dd>
     The <a>base IRI</a> is an <a>absolute IRI</a> established in the <a>context</a>,
     or is based on the <a>JSON-LD document</a> location.
     The <a>base IRI</a> is used to turn <a>relative IRIs</a> into <a>absolute IRIs</a>.</dd>
-  <dt><dfn>blank node</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-blank-node">blank node</dfn></dt><dd>
     A <a>node</a> in a <a>graph</a> that is neither an <a>IRI</a>,
     nor a <a>JSON-LD value</a>, nor a <a>list</a>.
-    A <a data-cite="RDF11-CONCEPTS#dfn-blank-node" class="externalDFN">blank node</a> does not contain
+    A <a>blank node</a> does not contain
     a de-referenceable identifier because it is either ephemeral in nature
     or does not contain information that needs to be linked to from outside of the <a>linked data graph</a>.
     A blank node is assigned an identifier starting with the prefix <code>_:</code>.</dd>
-  <dt><dfn>blank node identifier</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-blank-node-identifier" class="externalDFN">blank node identifier</a>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-blank-node-identifier">blank node identifier</dfn></dt><dd>
+    A <a>blank node identifier</a>
     is a string that can be used as an identifier for a <a>blank node</a> within the scope of a JSON-LD document.
     Blank node identifiers begin with <code>_:</code>.</dd>
   <dt><dfn>compact IRI</dfn></dt><dd>
@@ -92,12 +92,10 @@
   <dt><dfn>context</dfn></dt><dd>
     A set of rules for interpreting a <a>JSON-LD document</a>
     as specified in the <a data-cite="JSON-LD11#the-context">The Context</a> section of the JSON-LD Syntax specification [[JSON-LD11]].</dd>
-  <dt><dfn>datatype IRI</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-datatype-iri" class="externalDFN">datatype IRI</a>
-    as specified by [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn>default graph</dfn></dt><dd>
-    The <a data-cite="RDF11-CONCEPTS#dfn-default-graph" class="externalDFN">default graph</a>
-    is the only graph in a JSON-LD document which has no <a>graph name</a>.
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-datatype-iri">datatype IRI</dfn></dt><dd>
+    A <a>datatype IRI</a> as specified by [[RDF11-CONCEPTS]].</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-default-graph">default graph</dfn></dt><dd>
+    The <a>default graph</a> is the only graph in a JSON-LD document which has no <a>graph name</a>.
     When executing an algorithm,
     the graph where data should be placed if a <a>named graph</a> is not specified.</dd>
   <dt><dfn>default language</dfn></dt><dd>
@@ -105,13 +103,6 @@
     whose value MUST be a <a>string</a> representing a [[BCP47]] language code or <code>null</code>.</dd>
   <dt><dfn>default object</dfn></dt><dd>
     A <a>default object</a> is a <a>dictionary</a> that has a <code>@default</code> key.</dd>
-  <dt><dfn>edge</dfn></dt><dd>
-    Every <a>edge</a> has a direction associated with it
-    and is labeled with an <a>IRI</a> or a <a>blank node identifier</a>.
-    Within the JSON-LD syntax these edge labels are called <a>properties</a>.
-    Whenever possible, an <a>edge</a> should be labeled with an <a>IRI</a>.
-    <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
-      and may be removed in a future version of JSON-LD.</div></dd>
   <dt><dfn>embedded context</dfn></dt><dd>
     An embedded <a>context</a> is a <a>dictionary</a> composed of a combintation of
     <a>term definitions</a>, a <a>vocabulary mapping</a>, a <a>base IRI</a> and <a>default language</a>.
@@ -141,8 +132,8 @@
     which represents a specific portion of the <a>frame</a> matching either
     a <a>node object</a> or a <a>value object</a>
     in the input.</dd>
-  <dt><dfn>graph name</dfn></dt><dd>
-    The <a>IRI</a> or <a>blank node</a> identifying a <a data-cite="RDF11-CONCEPTS#dfn-graph-name" class="externalDFN">named graph</a>.</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-graph-name">graph name</dfn></dt><dd>
+    The <a>IRI</a> or <a>blank node</a> identifying a <a>named graph</a>.</dd>
   <dt class="changed"><dfn>id map</dfn></dt><dd class="changed">
     An <a>id map</a> is a <a>dictionary</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@id</code>.
@@ -168,8 +159,8 @@
     whose values MUST be any of the following types:
     <a>string</a>,
     <a>number</a>,
-    <a>true</a>,
-    <a>false</a>,
+    <code>true</code>,
+    <code>false</code>,
     <a>null</a>,
     <a>node object</a>,
     <a>value object</a>,
@@ -187,7 +178,7 @@
   <dt><dfn>JSON-LD value</dfn></dt><dd>
     A <a>JSON-LD value</a> is a <a>string</a>,
     a <a>number</a>,
-    <a>true</a> or <a>false</a>,
+    <code>true</code> or <code>false</code>,
     a <a>typed value</a>,
     or a <a>language-tagged string</a>.
   </dd>
@@ -204,34 +195,30 @@
     <a>string</a>, or
     an <a>array</a> of zero or more of the above possibilities.
   </dd>
-  <dt><dfn>language-tagged string</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-language-tagged-string" class="externalDFN">language-tagged string</a>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-language-tagged-string">language-tagged string</dfn></dt><dd>
+    A <a>language-tagged string</a>
     consists of a string and a non-empty language tag
     as defined by [[BCP47]].
-    The <dfn>language tag</dfn> MUST be well-formed
+    The <dfn data-cite="RDF11-CONCEPTS#dfn-language-tag">language tag</dfn> MUST be well-formed
     according to <a data-cite="BCP47#section-2.2.9">section 2.2.9 Classes of Conformance</a> of [[BCP47]],
     and is normalized to lowercase.</dd>
-  <dt><dfn>Linked Data</dfn></dt><dd>
+  <dt><dfn data-cite="LINKED-DATA" data-no-xref="">Linked Data</dfn></dt><dd>
     A set of documents, each containing a representation of a <a>linked data graph</a>.</dd>
-  <dt><dfn data-lt="graph">linked data graph</dfn></dt><dd>
-    A labeled directed <a data-cite="RDF11-CONCEPTS#dfn-rdf-graph" class="externalDFN">graph</a>,
-    i.e., a set of <a>nodes</a> connected by <a>edges</a>,
-    as specified in the <a data-cite="JSON-LD11#data-model">Data Model</a> section of the JSON-LD specification [[JSON-LD11]].
-    A <a>linked data graph</a> is a generalized representation of an <dfn class="preserve" data-cite="RDF11-CONCEPTS#dfn-rdf-graph">RDF graph</dfn>
-    as defined in [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn>list</dfn></dt><dd>
-    A <a>list</a> is an ordered sequence of <a>IRIs</a>, <a>blank nodes</a>, and <a>JSON-LD values</a>.
-    See <dfn data-cite="RDF-SCHEMA#ch_collectionvocab" data-lt="collection" class="preserve">RDF collection</dfn> in [[RDF-SCHEMA]].</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-graph" data-lt="graph|RDF graph">linked data graph</dfn></dt><dd>
+    A labeled directed <a>graph</a>,
+    i.e., a set of <a>nodes</a> connected by directed-arcs.</dd>
+  <dt><dfn data-cite="RDF-SCHEMA#ch_collectionvocab" data-lt="collection|RDF collection">list</dfn></dt><dd>
+    A <a>list</a> is an ordered sequence of <a>IRIs</a>, <a>blank nodes</a>, and <a>JSON-LD values</a>.</dd>
   <dt><dfn>list object</dfn></dt><dd>
     A <a>list object</a> is a <a>dictionary</a> that has a <code>@list</code> key.
     It may also have an <code>@index</code> key, but no other members.</dd>
-  <dt><dfn>literal</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-literal" data-lt="RDF literal">literal</dfn></dt><dd>
     An <a>object</a> expressed as a value such as a string or number, or in expanded form as a <a>value object</a>.</dd>
   <dt><dfn>local context</dfn></dt><dd>
     A <a>context</a> that is specified with a <a>dictionary</a>,
     specified via the <code>@context</code> <a>keyword</a>.</dd>
-  <dt><dfn>named graph</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-named-graph" class="externalDFN">named graph</a>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-named-graph">named graph</dfn></dt><dd>
+    A <a>named graph</a>
     is a <a>linked data graph</a> that is identified by an <a>IRI</a> or <a>blank node</a>.</dd>
   <dt><dfn>implicitly named graph</dfn></dt><dd>
     A <a>named graph</a> created from the value of a <a>dictionary member</a>
@@ -242,8 +229,8 @@
     whose value is a <a>dictionary</a> containing <a>members</a> which are treated as if they were values of the <a>node object</a>.
     The <a>nested property</a> itself is semantically meaningless and used only to create a sub-structure within a <a>node object</a>.
   </dd>
-  <dt><dfn>node</dfn></dt><dd>
-    Every <a data-cite="RDF11-CONCEPTS#dfn-node" class="externalDFN">node</a> is an <a>IRI</a>,
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-node">node</dfn></dt><dd>
+    Every <a>node</a> is an <a>IRI</a>,
     a <a>blank node</a>,
     a <a>JSON-LD value</a>,
     or a <a>list</a>.
@@ -262,8 +249,8 @@
   </dd>
   <dt><dfn>node reference</dfn></dt><dd>
     A <a>node object</a> used to reference a node having only the <code>@id</code> key.</dd>
-  <dt><dfn>object</dfn></dt><dd>
-    An <a data-cite="RDF11-CONCEPTS#dfn-object" class="externalDFN">object</a> is a <a>node</a> in a <a>linked data graph</a>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-object">object</dfn></dt><dd>
+    An <a>object</a> is a <a>node</a> in a <a>linked data graph</a>
     with at least one incoming edge.
     See <dfn data-cite="RDF11-CONCEPTS#dfn-object" class="preserve">RDF object</dfn> in [[RDF11-CONCEPTS]].</dd>
   <dt><dfn>prefix</dfn></dt><dd>
@@ -278,26 +265,23 @@
     or via explicit API option,
     other processing modes can be accessed.
     This specification defines extensions for the <code>json-ld-1.1</code> <a>processing mode</a>.</dd>
-  <dt><dfn>property</dfn></dt><dd>
-    The <a>IRI</a> label of an edge in a <a>linked data graph</a>.
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-property">property</dfn></dt><dd>
+    The name of a direct-arc in a <a>linked data graph</a>.
+    Every <a>property</a> is directional
+    and is labeled with an <a>IRI</a> or a <a>blank node identifier</a>.
+    Whenever possible, a <a>property</a> should be labeled with an <a>IRI</a>.
+    <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
+      and may be removed in a future version of JSON-LD.</div></dd>
     See <dfn data-cite="RDF11-CONCEPTS#dfn-predicate" data-lt="predicate" class="preserve">RDF predicate</dfn> in [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn>quad</dfn></dt><dd>
-    A piece of information that contains four items;
-    a <a>subject</a>,
-    a <a>property</a>,
-    an <a>object</a>,
-    and a <a>graph name</a>.</dd>
-  <dt><dfn data-lt="dataset">RDF dataset</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-rdf-dataset" class="externalDFN">dataset</a>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-dataset" data-lt="dataset">RDF dataset</dfn></dt><dd>
+    A <a>dataset</a>
     as specified by [[RDF11-CONCEPTS]]
     representing a collection of <a data-cite="RDF11-CONCEPTS#dfn-rdf-graph">RDF graphs</a>.</dd>
-  <dt><dfn data-lt="resource">RDF resource</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-resource" class="externalDFN">resource</a>
-    as specified by [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn data-lt="triple">RDF triple</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-rdf-triple" class="externalDFN">triple</a>
-    as specified by [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn>relative IRI</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-resource" data-lt="resource">RDF resource</dfn></dt><dd>
+    A <a >resource</a> as specified by [[RDF11-CONCEPTS]].</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-triple" data-lt="triple">RDF triple</dfn></dt><dd>
+    A <a>triple</a> as specified by [[RDF11-CONCEPTS]].</dd>
+  <dt><dfn data-cite="RFC3987#section-6.5">relative IRI</dfn></dt><dd>
     A relative IRI is an <a>IRI</a> that is relative to some other <a>absolute IRI</a>,
     typically the <a>base IRI</a> of the document.
     Note that <a>properties</a>,
@@ -308,9 +292,8 @@
   <dt><dfn>set object</dfn></dt><dd>
     A <a>set object</a> is a <a>dictionary</a> that has an <code>@set</code> <a>member</a>.
     It may also have an <code>@index</code> key, but no other members.</dd>
-  <dt><dfn>subject</dfn></dt><dd>
-    A <a data-cite="RDF11-CONCEPTS#dfn-subject" class="externalDFN">subject</a>
-    is a <a>node</a> in a <a>linked data graph</a>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-subject">subject</dfn></dt><dd>
+    A <a>subject</a> is a <a>node</a> in a <a>linked data graph</a>
     with at least one outgoing edge,
     related to an <a>object</a> node through a <a>property</a>.
     See <dfn data-cite="RDF11-CONCEPTS#dfn-subject" class="preserve">RDF subject</dfn> in [[RDF11-CONCEPTS]].</dd>
@@ -336,15 +319,11 @@
     If the value contains a <a>term</a> expanding to <code>@type</code>,
     it's values are merged with the map value when expanding.</dd>
   <dt><dfn>JSON literal</dfn></dt><dd>
-    A <a>JSON literal</a> is a <a>typed literal</a> where the associated <a>IRI</a> is <code>rdf:JSON</code>.
+    A <a>JSON literal</a> is a <a>literal</a> where the associated <a>IRI</a> is <code>rdf:JSON</code>.
     In the <a>value object</a> representation, the value of <code>@type</code> is <code>@json</code>.
     JSON literals represent values which are valid JSON [[RFC8259]].
     See <dfn data-cite="JSON-LD11#dfn-json-datatype" class="preserve">JSON datatype</dfn> in [[JSON-LD11]].
   </dd>
-  <dt><dfn>typed literal</dfn></dt><dd>
-    A <a>typed literal</a> is a <a>literal</a> with an associated <a>IRI</a>
-    which indicates the literal's datatype.
-    See <dfn data-cite="RDF11-CONCEPTS#dfn-literal" class="preserve">RDF literal</dfn> in [[RDF11-CONCEPTS]].</dd>
   <dt><dfn>typed value</dfn></dt><dd>
     A <a>typed value</a> consists of a value,
     which is a <a>string</a>,

--- a/common/terms.html
+++ b/common/terms.html
@@ -1,20 +1,20 @@
 <dl class="termlist" data-sort>
-  <dt><dfn data-cite="ECMASCRIPT#sec-array-objects">array</dfn></dt><dd>
+  <dt><dfn data-cite="INFRA#list" class="preserve">array</dfn></dt><dd>
     In the JSON serialization,
-    an array structure is represented as square brackets surrounding zero or more values.
+    an <a>array</a> structure is represented as square brackets surrounding zero or more values.
     Values are separated by commas.
     In the <a>internal representation</a>,
-    an array is an <em>ordered</em> collection of zero or more values.
+    a <a data-ld="array">list</a> (also called an <a>array</a>) is an <em>ordered</em> collection of zero or more values.
     While JSON-LD uses the same array representation as JSON,
     the collection is <em>unordered</em> by default.
     While order is preserved in regular JSON arrays,
     it is not in regular JSON-LD arrays unless specifically defined
     (see <a data-cite="JSON-LD11#sets-and-lists">Sets and Lists</a>
     in the JSON-LD Syntax specification [[JSON-LD11]]).</dd>
-  <dt><dfn data-cite="RFC8259#section-4">JSON object</dfn></dt><dd>
+  <dt><dfn data-cite="RFC8259#section-4" class="preserve">JSON object</dfn></dt><dd>
     In the JSON serialization,
     an <a>object</a> structure
-    is represented as a pair of curly brackets surrounding zero or more members
+    is represented as a pair of curly brackets surrounding zero or more <a>entries</a>
     composed of name-value pairs.
     A name is a <a>string</a>.
     A single colon comes after each name,
@@ -22,25 +22,25 @@
     A single comma separates a value from a following name.
     In JSON-LD the names in an object MUST be unique.
     In the <a>internal representation</a> a <a>JSON object</a> is described as a
-    <dfn data-cite="WEBIDL#dfn-dictionary" class="preserve">dictionary</dfn> (see [[WEBIDL]]),
-    composed of <dfn data-cite="WEBIDL#dfn-dictionary-member" data-lt="dictionary member|member" class="preserve">dictionary members</dfn> with key-value pairs.</dd>
+    <dfn data-cite="INFRA#ordered-map" class="preserve">map</dfn> (see [[INFRA]]),
+    composed of <dfn data-cite="INFRA#map-entry" data-lt="map entry|entry" data-ld-noDefault class="preserve">entries</dfn> with key-value pairs.</dd>
   <dt class="changed"><dfn data-lt="internal representation">JSON-LD internal representation</dfn></dt><dd class="changed">
     The JSON-LD internal representation
     is the result of transforming a JSON syntactic structure
     into the core data structures suitable for direct processing:
-    <a>arrays</a>, <a>dictionaries</a>, <a>strings</a>, <a>numbers</a>, <a>booleans</a>, and <a>null</a>.</dd>
-  <dt><dfn data-cite="ECMASCRIPT#sec-null-value">null</dfn></dt><dd>
-    The use of the <a data-cite="RFC8259#section-3">null</a> value within JSON-LD
+    <a>arrays</a>, <a>maps</a>, <a>strings</a>, <a>numbers</a>, <a>booleans</a>, and <a>null</a>.</dd>
+  <dt><dfn data-cite="INFRA#nulls" class="preserve">null</dfn></dt><dd>
+    The use of the <a>null</a> value within JSON-LD
     is used to ignore or reset values.
-    A <a>dictionary member</a> in the <code>@context</code> where the value,
+    A <a>map entry</a> in the <code>@context</code> where the value,
     or the <code>@id</code> of the value, is <code>null</code>,
     explicitly decouples a term's association with an IRI.
-    A <a>dictionary member</a> in the body of a <a>JSON-LD document</a>
+    A <a>map entry</a> in the body of a <a>JSON-LD document</a>
     whose value is <code>null</code>
-    has the same meaning as if the <a>dictionary member</a> was not defined.
+    has the same meaning as if the <a>map entry</a> was not defined.
     If <code>@value</code>, <code>@list</code>, or <code>@set</code> is set to <code>null</code> in expanded form,
     then the entire <a>JSON object</a> is ignored.</dd>
-  <dt><dfn data-cite="ECMASCRIPT#sec-terms-and-definitions-number-value" data-lt="number|JSON number">number</dfn></dt><dd>
+  <dt><dfn data-cite="ECMASCRIPT#sec-terms-and-definitions-number-value" data-lt="number|JSON number" class="preserve">number</dfn></dt><dd>
     In the JSON serialization, a <a>number</a>
     is similar to that used in most programming languages,
     except that the octal and hexadecimal formats are not used and that leading zeros are not allowed.
@@ -48,14 +48,14 @@
     a <a>number</a> is equivalent to either a <dfn data-cite="WEBIDL#idl-long" class="preserve">long</dfn>
     or <dfn data-cite="WEBIDL#idl-double" class="preserve">double</dfn>,
     depending on if the number has a non-zero fractional part (see [[WEBIDL]]).</dd>
-  <dt><dfn data-cite="#sec-primitive-value" data-no-xref="">scalar</dfn></dt><dd>
-    A scalar is either a JSON <a>string</a>, <a>number</a>, <code>true</code>, or <code>false</code>.</dd>
-  <dt><dfn data-cite="ECMASCRIPT#sec-terms-and-definitions-string-value">string</dfn></dt><dd>
+  <dt><dfn data-cite="INFRA#primitive-data-types" class="preserve">scalar</dfn></dt><dd>
+    A scalar is either a <a>string</a>, <a>number</a>, <code>true</code>, or <code>false</code>.</dd>
+  <dt><dfn data-cite="INFRA##javascript-string" class="preserve">string</dfn></dt><dd>
     A <a>string</a>
     is a sequence of zero or more Unicode (UTF-8) characters,
     wrapped in double quotes, using backslash escapes (if necessary).
     A character is represented as a single character string.</dd>
-  <dt><dfn data-cite="ECMASCRIPT#sec-terms-and-definitions-boolean-value">boolean</dfn></dt><dd>
+  <dt><dfn data-cite="INFRA#boolean" class="preserve">boolean</dfn></dt><dd>
     The values <code>true</code> and <code>false</code> that are used
     to express one of two possible states.</dd>
 </dl>
@@ -63,25 +63,25 @@
 <p>Furthermore, the following terminology is used throughout this document:</p>
 
 <dl class="termlist" data-sort>
-  <dt><dfn data-cite="RFC3987#section-1.3">absolute IRI</dfn></dt><dd>
+  <dt><dfn data-cite="RFC3987#section-1.3" class="preserve">absolute IRI</dfn></dt><dd>
     An <a>absolute IRI</a>
     is defined in [[RFC3987]] containing a <em>scheme</em> along with a <em>path</em>
     and optional <em>query</em> and fragment segments.</dd>
   <dt><dfn>active context</dfn></dt><dd>
     A <a>context</a> that is used to resolve <a>terms</a>
     while the processing algorithm is running.</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-base-iri">base IRI</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-base-iri" class="preserve">base IRI</dfn></dt><dd>
     The <a>base IRI</a> is an <a>absolute IRI</a> established in the <a>context</a>,
     or is based on the <a>JSON-LD document</a> location.
     The <a>base IRI</a> is used to turn <a>relative IRIs</a> into <a>absolute IRIs</a>.</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-blank-node">blank node</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-blank-node" class="preserve">blank node</dfn></dt><dd>
     A <a>node</a> in a <a>graph</a> that is neither an <a>IRI</a>,
     nor a <a>JSON-LD value</a>, nor a <a>list</a>.
     A <a>blank node</a> does not contain
     a de-referenceable identifier because it is either ephemeral in nature
     or does not contain information that needs to be linked to from outside of the <a>linked data graph</a>.
     A blank node is assigned an identifier starting with the prefix <code>_:</code>.</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-blank-node-identifier">blank node identifier</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-blank-node-identifier" class="preserve">blank node identifier</dfn></dt><dd>
     A <a>blank node identifier</a>
     is a string that can be used as an identifier for a <a>blank node</a> within the scope of a JSON-LD document.
     Blank node identifiers begin with <code>_:</code>.</dd>
@@ -92,9 +92,9 @@
   <dt><dfn>context</dfn></dt><dd>
     A set of rules for interpreting a <a>JSON-LD document</a>
     as specified in the <a data-cite="JSON-LD11#the-context">The Context</a> section of the JSON-LD Syntax specification [[JSON-LD11]].</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-datatype-iri">datatype IRI</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-datatype-iri" class="preserve">datatype IRI</dfn></dt><dd>
     A <a>datatype IRI</a> as specified by [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-default-graph">default graph</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-default-graph" class="preserve">default graph</dfn></dt><dd>
     The <a>default graph</a> is the only graph in a JSON-LD document which has no <a>graph name</a>.
     When executing an algorithm,
     the graph where data should be placed if a <a>named graph</a> is not specified.</dd>
@@ -102,20 +102,20 @@
     The default language is set in the <a>context</a> using the <code>@language</code> key
     whose value MUST be a <a>string</a> representing a [[BCP47]] language code or <code>null</code>.</dd>
   <dt><dfn>default object</dfn></dt><dd>
-    A <a>default object</a> is a <a>dictionary</a> that has a <code>@default</code> key.</dd>
+    A <a>default object</a> is a <a>map</a> that has a <code>@default</code> key.</dd>
   <dt><dfn>embedded context</dfn></dt><dd>
-    An embedded <a>context</a> is a <a>dictionary</a> composed of a combintation of
+    An embedded <a>context</a> is a <a>map</a> composed of a combintation of
     <a>term definitions</a>, a <a>vocabulary mapping</a>, a <a>base IRI</a> and <a>default language</a>.
     An <a>embedded context</a> may appear as part of a <a>node object</a> or <a>value object</a> using the
-    <code>@context</code> <a>member</a>.
+    <code>@context</code> <a>entry</a>.
   </dd>
   <dt><dfn>scoped context</dfn></dt><dd>
     A <a>scoped context</a> is part of an <a>expanded term definition</a> using the
-    <code>@context</code> <a>member</a>. It has the same form as an <a>embedded context</a>.
+    <code>@context</code> <a>entry</a>. It has the same form as an <a>embedded context</a>.
   </dd>
   <dt><dfn>expanded term definition</dfn></dt><dd>
     An expanded term definition is a <a>term definition</a>
-    where the value is a <a>dictionary</a>
+    where the value is a <a>map</a>
     containing one or more <a>keyword</a> keys to define the associated <a>absolute IRI</a>,
     if this is a reverse property,
     the type associated with string values, and a container mapping.</dd>
@@ -123,19 +123,19 @@
     A <a>JSON-LD document</a>,
     which describes the form for transforming another <a>JSON-LD document</a>
     using matching and embedding rules.
-    A frame document allows additional keywords and certain <a>dictionary members</a>
+    A frame document allows additional keywords and certain <a>map entries</a>
     to describe the matching and transforming process.</dd>
   <dt><dfn data-lt="json-ld processor|Processors">JSON-LD Processor</dfn></dt><dd>
     A <a>JSON-LD Processor</a> is a system which can perform the algorithms defined in [[JSON-LD11-API]].</dd>
   <dt><dfn>frame object</dfn></dt><dd>
-    A frame object is a <a>dictionary</a> element within a <a>frame</a>
+    A frame object is a <a>map</a> element within a <a>frame</a>
     which represents a specific portion of the <a>frame</a> matching either
     a <a>node object</a> or a <a>value object</a>
     in the input.</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-graph-name">graph name</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-graph-name" class="preserve">graph name</dfn></dt><dd>
     The <a>IRI</a> or <a>blank node</a> identifying a <a>named graph</a>.</dd>
   <dt class="changed"><dfn>id map</dfn></dt><dd class="changed">
-    An <a>id map</a> is a <a>dictionary</a> value of a <a>term</a>
+    An <a>id map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@id</code>.
     The values of the <a>id map</a> MUST be <a>node objects</a>,
     and its keys are interpreted as <a>IRIs</a> representing
@@ -144,17 +144,17 @@
     it's value MUST be equivalent to the referencing key in the <a>id map</a>.</dd>
   <dt class="changed"><dfn>graph object</dfn></dt><dd class="changed">
     A <a>graph object</a> represents a <a>named graph</a>
-    as the value of a <a>dictionary member</a> within a <a>node object</a>.
-    When expanded, a graph object MUST have an <code>@graph</code> <a>member</a>,
-    and MAY also have <code>@id</code>, and <code>@index</code> <a>members</a>.
+    as the value of a <a>map entry</a> within a <a>node object</a>.
+    When expanded, a graph object MUST have an <code>@graph</code> <a>entry</a>,
+    and MAY also have <code>@id</code>, and <code>@index</code> <a>entries</a>.
     A <dfn class="preserve">simple graph object</dfn>
-    is a <a>graph object</a> which does not have an <code>@id</code> <a>member</a>.
-    Note that <a>node objects</a> may have a <code>@graph</code> member,
-    but are not considered <a>graph objects</a> if they include any other <a>members</a>.
+    is a <a>graph object</a> which does not have an <code>@id</code> <a>entry</a>.
+    Note that <a>node objects</a> may have a <code>@graph</code> <a>entry</a>,
+    but are not considered <a>graph objects</a> if they include any other <a>entries</a>.
     A top-level object consisting of <code>@graph</code> is also not a <a>graph object</a>.
     Note that a <a>node object</a> may also represent a <a>named graph</a> it it includes other properties.</dd>
   <dt><dfn>index map</dfn></dt><dd>
-    An <a>index map</a> is a <a>dictionary</a> value of a <a>term</a>
+    An <a>index map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@index</code>,
     whose values MUST be any of the following types:
     <a>string</a>,
@@ -168,7 +168,7 @@
     <a>set object</a>, or
     an <a>array</a> of zero or more of the above possibilities.
   </dd>
-  <dt><dfn data-lt="IRI|Internationalized Resource Identifier"><abbr title="Internationalized Resource Identifier">IRI</abbr></dfn></dt><dd>
+  <dt><dfn data-lt="IRI|Internationalized Resource Identifier" class="preserve"><abbr title="Internationalized Resource Identifier">IRI</abbr></dfn></dt><dd>
     An <a data-cite="RFC3987#section-1.3" class="externalDFN">Internationalized Resource Identifier</a>
     as described in [[RFC3987]].</dd>
   <dt><dfn>JSON-LD document</dfn></dt><dd>
@@ -187,7 +187,7 @@
     specified in the JSON-LD Syntax specification [[JSON-LD11]]
     in the section titled <a data-cite="JSON-LD11#syntax-tokens-and-keywords">Syntax Tokens and Keywords</a>.</dd>
   <dt><dfn>language map</dfn></dt><dd>
-    An <a>language map</a> is a <a>dictionary</a> value of a <a>term</a>
+    An <a>language map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@language</code>,
     whose keys MUST be <a>strings</a> representing [[BCP47]] language codes
     and the values MUST be any of the following types:
@@ -195,41 +195,41 @@
     <a>string</a>, or
     an <a>array</a> of zero or more of the above possibilities.
   </dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-language-tagged-string">language-tagged string</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-language-tagged-string" class="preserve">language-tagged string</dfn></dt><dd>
     A <a>language-tagged string</a>
     consists of a string and a non-empty language tag
     as defined by [[BCP47]].
     The <dfn data-cite="RDF11-CONCEPTS#dfn-language-tag">language tag</dfn> MUST be well-formed
     according to <a data-cite="BCP47#section-2.2.9">section 2.2.9 Classes of Conformance</a> of [[BCP47]],
     and is normalized to lowercase.</dd>
-  <dt><dfn data-cite="LINKED-DATA" data-no-xref="">Linked Data</dfn></dt><dd>
+  <dt><dfn data-cite="LINKED-DATA" data-no-xref="" class="preserve">Linked Data</dfn></dt><dd>
     A set of documents, each containing a representation of a <a>linked data graph</a>.</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-graph" data-lt="graph|RDF graph">linked data graph</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-graph" data-lt="graph|RDF graph" class="preserve">linked data graph</dfn></dt><dd>
     A labeled directed <a>graph</a>,
     i.e., a set of <a>nodes</a> connected by directed-arcs.</dd>
-  <dt><dfn data-cite="RDF-SCHEMA#ch_collectionvocab" data-lt="collection|RDF collection">list</dfn></dt><dd>
+  <dt><dfn data-cite="RDF-SCHEMA#ch_collectionvocab" data-lt="collection|RDF collection" class="preserve">list</dfn></dt><dd>
     A <a>list</a> is an ordered sequence of <a>IRIs</a>, <a>blank nodes</a>, and <a>JSON-LD values</a>.</dd>
   <dt><dfn>list object</dfn></dt><dd>
-    A <a>list object</a> is a <a>dictionary</a> that has a <code>@list</code> key.
-    It may also have an <code>@index</code> key, but no other members.</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-literal" data-lt="RDF literal">literal</dfn></dt><dd>
+    A <a>list object</a> is a <a>map</a> that has a <code>@list</code> key.
+    It may also have an <code>@index</code> key, but no other <a>entries</a>.</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-literal" data-lt="RDF literal" class="preserve">literal</dfn></dt><dd>
     An <a>object</a> expressed as a value such as a string or number, or in expanded form as a <a>value object</a>.</dd>
   <dt><dfn>local context</dfn></dt><dd>
-    A <a>context</a> that is specified with a <a>dictionary</a>,
+    A <a>context</a> that is specified with a <a>map</a>,
     specified via the <code>@context</code> <a>keyword</a>.</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-named-graph">named graph</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-named-graph" class="preserve">named graph</dfn></dt><dd>
     A <a>named graph</a>
     is a <a>linked data graph</a> that is identified by an <a>IRI</a> or <a>blank node</a>.</dd>
   <dt><dfn>implicitly named graph</dfn></dt><dd>
-    A <a>named graph</a> created from the value of a <a>dictionary member</a>
+    A <a>named graph</a> created from the value of a <a>map entry</a>
     having an <a>expanded term definition</a>
     where <code>@container</code> is set to  <code>@graph</code>.</dd>
   <dt><dfn>nested property</dfn></dt><dd>
     A <a>nested property</a> is a key in a <a>node object</a>
-    whose value is a <a>dictionary</a> containing <a>members</a> which are treated as if they were values of the <a>node object</a>.
+    whose value is a <a>map</a> containing <a>entries</a> which are treated as if they were values of the <a>node object</a>.
     The <a>nested property</a> itself is semantically meaningless and used only to create a sub-structure within a <a>node object</a>.
   </dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-node">node</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-node" class="preserve">node</dfn></dt><dd>
     Every <a>node</a> is an <a>IRI</a>,
     a <a>blank node</a>,
     a <a>JSON-LD value</a>,
@@ -238,18 +238,18 @@
   <dt><dfn>node object</dfn></dt><dd>
     A <a>node object</a> represents zero or more <a>properties</a> of a <a>node</a> in the <a>graph</a>
     serialized by the <a>JSON-LD document</a>.
-    A <a>dictionary</a> is a <a>node object</a>
+    A <a>map</a> is a <a>node object</a>
     if it exists outside of the JSON-LD <a>context</a> and:
     <ul>
       <li>it does not contain the <code>@value</code>, <code>@list</code>, or <code>@set</code> keywords, or</li>
-      <li>it is not the top-most <a>dictionary</a> in the JSON-LD document
-        consisting of no other <a>members</a> than <code>@graph</code> and <code>@context</code>.</li>
+      <li>it is not the top-most <a>map</a> in the JSON-LD document
+        consisting of no other <a>entries</a> than <code>@graph</code> and <code>@context</code>.</li>
     </ul>
-    The <a>members</a> of a <a>node object</a> whose keys are not keywords are also called <a>properties</a> of the <a>node object</a>.
+    The <a>entries</a> of a <a>node object</a> whose keys are not keywords are also called <a>properties</a> of the <a>node object</a>.
   </dd>
   <dt><dfn>node reference</dfn></dt><dd>
     A <a>node object</a> used to reference a node having only the <code>@id</code> key.</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-object">object</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-object" class="preserve">object</dfn></dt><dd>
     An <a>object</a> is a <a>node</a> in a <a>linked data graph</a>
     with at least one incoming edge.
     See <dfn data-cite="RDF11-CONCEPTS#dfn-object" class="preserve">RDF object</dfn> in [[RDF11-CONCEPTS]].</dd>
@@ -261,11 +261,11 @@
   <dt><dfn>processing mode</dfn></dt><dd>
     The processing mode defines how a JSON-LD document is processed.
     By default, all documents are assumed to be conformant with <a data-cite="JSON-LD" data-no-xref="">JSON-LD 1.0</a> [[JSON-LD]].
-    By defining a different version using the <code>@version</code> <a>member</a> in a <a>context</a>,
+    By defining a different version using the <code>@version</code> <a>entry</a> in a <a>context</a>,
     or via explicit API option,
     other processing modes can be accessed.
     This specification defines extensions for the <code>json-ld-1.1</code> <a>processing mode</a>.</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-property">property</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-property" class="preserve">property</dfn></dt><dd>
     The name of a direct-arc in a <a>linked data graph</a>.
     Every <a>property</a> is directional
     and is labeled with an <a>IRI</a> or a <a>blank node identifier</a>.
@@ -273,15 +273,15 @@
     <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
       and may be removed in a future version of JSON-LD.</div></dd>
     See <dfn data-cite="RDF11-CONCEPTS#dfn-predicate" data-lt="predicate" class="preserve">RDF predicate</dfn> in [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-dataset" data-lt="dataset">RDF dataset</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-dataset" data-lt="dataset" class="preserve">RDF dataset</dfn></dt><dd>
     A <a>dataset</a>
     as specified by [[RDF11-CONCEPTS]]
     representing a collection of <a data-cite="RDF11-CONCEPTS#dfn-rdf-graph">RDF graphs</a>.</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-resource" data-lt="resource">RDF resource</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-resource" data-lt="resource" class="preserve">RDF resource</dfn></dt><dd>
     A <a >resource</a> as specified by [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-triple" data-lt="triple">RDF triple</dfn></dt><dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-triple" data-lt="triple" class="preserve">RDF triple</dfn></dt><dd>
     A <a>triple</a> as specified by [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn data-cite="RFC3987#section-6.5">relative IRI</dfn></dt><dd>
+  <dt><dfn data-cite="RFC3987#section-6.5" class="preserve">relative IRI</dfn></dt><dd>
     A relative IRI is an <a>IRI</a> that is relative to some other <a>absolute IRI</a>,
     typically the <a>base IRI</a> of the document.
     Note that <a>properties</a>,
@@ -290,9 +290,9 @@
     are resolved relative to the <a>vocabulary mapping</a>,
     not the <a>base IRI</a>.</dd>
   <dt><dfn>set object</dfn></dt><dd>
-    A <a>set object</a> is a <a>dictionary</a> that has an <code>@set</code> <a>member</a>.
-    It may also have an <code>@index</code> key, but no other members.</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-subject">subject</dfn></dt><dd>
+    A <a>set object</a> is a <a>map</a> that has an <code>@set</code> <a>entry</a>.
+    It may also have an <code>@index</code> key, but no other <a>entries</a>.</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-subject" class="preserve">subject</dfn></dt><dd>
     A <a>subject</a> is a <a>node</a> in a <a>linked data graph</a>
     with at least one outgoing edge,
     related to an <a>object</a> node through a <a>property</a>.
@@ -304,14 +304,14 @@
   <dt><dfn>term definition</dfn></dt><dd>
     A term definition is an entry in a <a>context</a>,
     where the key defines a <a>term</a>
-    which may be used within a <a>dictionary</a>
+    which may be used within a <a>map</a>
     as a key, type, or elsewhere that a string is interpreted as a vocabulary item.
     Its value is either a string (<dfn data-lt="simple term">simple term definition</dfn>),
     expanding to an absolute IRI,
     or an <a>expanded term definition</a>.
   </dd>
   <dt class="changed"><dfn>type map</dfn></dt><dd class="changed">
-    An <a>type map</a> is a <a>dictionary</a> value of a <a>term</a>
+    An <a>type map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@type</code>,
     whose keys are interpreted as <a>IRIs</a>
     representing the <code>@type</code> of the associated <a>node object</a>;
@@ -330,7 +330,7 @@
     and a type,
     which is an <a>IRI</a>.</dd>
   <dt><dfn>value object</dfn></dt><dd>
-    A <a>value object</a> is a <a>dictionary</a> that has an <code>@value</code> <a>member</a>.</dd>
+    A <a>value object</a> is a <a>map</a> that has an <code>@value</code> <a>entry</a>.</dd>
   <dt><dfn>vocabulary mapping</dfn></dt><dd>
     The vocabulary mapping is set in the <a>context</a> using the <code>@vocab</code> key
     whose value MUST be an <a>IRI</a> or <code>null</code>.</dd>

--- a/common/terms.html
+++ b/common/terms.html
@@ -273,7 +273,7 @@
     results in an <a>absolute IRI</a>.</dd>
   <dt><dfn>processing mode</dfn></dt><dd>
     The processing mode defines how a JSON-LD document is processed.
-    By default, all documents are assumed to be conformant with <a data-cite="JSON-LD">JSON-LD 1.0</a> [[JSON-LD]].
+    By default, all documents are assumed to be conformant with <a data-cite="JSON-LD" data-no-xref="">JSON-LD 1.0</a> [[JSON-LD]].
     By defining a different version using the <code>@version</code> <a>member</a> in a <a>context</a>,
     or via explicit API option,
     other processing modes can be accessed.

--- a/common/typographical-conventions.html
+++ b/common/typographical-conventions.html
@@ -8,7 +8,7 @@
     or a file name is in red-orange monospace font.</dd>
   <dt><var>variable</var></dt><dd>
     A variable in pseudo-code or in an algorithm description is in italics.</dd>
-  <dt><dfn>definition</dfn></dt><dd>
+  <dt><dfn data-no-xref="">definition</dfn></dt><dd>
     A definition of a term, to be used elsewhere in this or other specifications,
     is in bold and italics.</dd>
   <dt><a data-lt="definition">definition reference</a></dt><dd>

--- a/index.html
+++ b/index.html
@@ -456,7 +456,7 @@
       <a>JSON-LD document</a> is a labeled,
       directed <a>graph</a>. The graph contains
       <a>nodes</a>, which are connected by
-      <a>edges</a>. A <a>node</a> is typically data
+      directed-arcs. A <a>node</a> is typically data
       such as a <a>string</a>, <a>number</a>,
       <a>typed values</a> (like dates and times)
       or an <a>IRI</a>.</p>
@@ -576,7 +576,7 @@
         in an <a>index map</a>, <a>id map</a>, <a>language map</a>, <a>type map</a>, or elsewhere where a dictionary is
         used to index into other values.</dd>
       <dt class="changed"><code>@prefix</code></dt><dd class="changed">
-        With the value <a>true</a>, allows this <a>term</a> to be used to construct a <a>compact IRI</a>
+        With the value <code>true</code>, allows this <a>term</a> to be used to construct a <a>compact IRI</a>
         when compacting.</dd>
       <dt class="changed"><code>@version</code></dt><dd class="changed">
         Used in a <a>context definition</a> to set the <a>processing mode</a>.
@@ -2786,7 +2786,7 @@
     when compacting only if
     a <a>simple term definition</a> is used where the value ends with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
     or if their <a>expanded term definition</a> contains
-    a <code>@prefix</code> <a>member</a> with the value <a>true</a>.</p>
+    a <code>@prefix</code> <a>member</a> with the value <code>true</code>.</p>
 
   <p class="note changed">The term selection behavior for 1.0 processors was changed
     as a result of an errata against [[[JSON-LD]]] reported <a href="https://lists.w3.org/Archives/Public/public-rdf-comments/2018Jan/0002.html">here</a>.
@@ -3923,7 +3923,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
   <li>By utilizing the <code>@type</code> <a>keyword</a> when defining
     a <a>term</a> within an <code>@context</code> section.</li>
   <li>By utilizing a <a>value object</a>.</li>
-  <li>By using a native JSON type such as <a>number</a>, <a>true</a>, or <a>false</a>.</li>
+  <li>By using a native JSON type such as <a>number</a>, <code>true</code>, or <code>false</code>.</li>
 </ol>
 
 <p>The first example uses the <code>@type</code> keyword to associate a
@@ -10949,11 +10949,11 @@ the data type to be specified explicitly with each piece of data.</p>
       and a <a>graph</a>. Whenever practical, the <a>graph name</a> SHOULD be an <a>IRI</a>.</li>
     <li>A <a>graph</a>
       is a labeled directed graph, i.e., a set of <a>nodes</a>
-      connected by <a>edges</a>.</li>
-    <li>Every <a>edge</a> has a direction associated with it and is labeled with
+      connected by directed-arcs.</li>
+    <li>Every directed-arc is labeled with
       an <a>IRI</a> or a <a>blank node identifier</a>. Within the JSON-LD syntax
-      these edge labels are called <a>properties</a>.
-      Whenever practical, an <a>edge</a> SHOULD be labeled with an <a>IRI</a>.
+      these arc labels are called <a>properties</a>.
+      Whenever practical, a directed-arc SHOULD be labeled with an <a>IRI</a>.
       <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
         and may be removed in a future version of JSON-LD.</div>
     </li>
@@ -10963,7 +10963,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <li>A <a>node</a> having an outgoing edge MUST be an <a>IRI</a> or a
       <a>blank node</a>.</li>
     <li>A <a>graph</a> MUST NOT contain unconnected <a>nodes</a>,
-      i.e., nodes which are not connected by an <a>edge</a> to any other <a>node</a>.
+      i.e., nodes which are not connected by an <a>property</a> to any other <a>node</a>.
       <pre class="illegal-example"
           data-transform="updateExample"
           data-ignore
@@ -10999,7 +10999,7 @@ the data type to be specified explicitly with each piece of data.</p>
         (see <a data-cite="JSON-LD11-API#data-gound-tripping">Data Round Tripping</a>) in [[JSON-LD11-API]]),</span>
       are interpreted as <a>typed values</a> with type <code>xsd:double</code>, all other
       <a>numbers</a> are interpreted as <a>typed values</a>
-      with type <code>xsd:integer</code>), <a>true</a> or <a>false</a> (which are interpreted as
+      with type <code>xsd:integer</code>), <code>true</code> or <code>false</code> (which are interpreted as
       <a>typed values</a> with type <code>xsd:boolean</code>),
       or a <a>language-tagged string</a>.</li>
     <li>A <a>typed value</a> consists of a value, which is a string, and a type, which is an
@@ -11340,8 +11340,8 @@ the data type to be specified explicitly with each piece of data.</p>
     <ul>
       <li><a>string</a>,</li>
       <li><a>number</a>,</li>
-      <li><a>true</a>,</li>
-      <li><a>false</a>,</li>
+      <li><code>true</code>,</li>
+      <li><code>false</code>,</li>
       <li><a>null</a>,</li>
       <li><a>node object</a>,</li>
       <li class="changed"><a>graph object</a>,</li>
@@ -11437,8 +11437,8 @@ the data type to be specified explicitly with each piece of data.</p>
       <a>absolute IRI</a> or <a>keyword</a>.</p>
 
     <p>The value associated with the <code>@value</code> key MUST be either a
-      <a>string</a>, a <a>number</a>, <a>true</a>,
-      <a>false</a> or <a>null</a>.
+      <a>string</a>, a <a>number</a>, <code>true</code>,
+      <code>false</code> or <a>null</a>.
       <span class="changed">If the value associated with the <code>@type</code> key</span>
       is <code>@json</code>, the value MAY be either an <a>array</a> or an <a>object</a>.</p>
 
@@ -11506,8 +11506,8 @@ the data type to be specified explicitly with each piece of data.</p>
     <ul>
       <li><a>string</a>,</li>
       <li><a>number</a>,</li>
-      <li><a>true</a>,</li>
-      <li><a>false</a>,</li>
+      <li><code>true</code>,</li>
+      <li><code>false</code>,</li>
       <li><a>null</a>,</li>
       <li><a>node object</a>,</li>
       <li><a>value object</a>, or</li>
@@ -11559,8 +11559,8 @@ the data type to be specified explicitly with each piece of data.</p>
     <ul>
       <li><a>string</a>,</li>
       <li><a>number</a>,</li>
-      <li><a>true</a>,</li>
-      <li><a>false</a>,</li>
+      <li><code>true</code>,</li>
+      <li><code>false</code>,</li>
       <li><a>null</a>,</li>
       <li><a>node object</a>,</li>
       <li><a>value object</a>,</li>
@@ -11866,8 +11866,8 @@ the data type to be specified explicitly with each piece of data.</p>
       <ul>
         <li><a>string</a>,</li>
         <li><a>number</a>,</li>
-        <li><a>true</a>,</li>
-        <li><a>false</a>,</li>
+        <li><code>true</code>,</li>
+        <li><code>false</code>,</li>
         <li><a>null</a>,</li>
         <li><a>node object</a>,</li>
         <li><a>value object</a>, or</li>
@@ -11917,8 +11917,8 @@ the data type to be specified explicitly with each piece of data.</p>
       <ul>
         <li><a>string</a>,</li>
         <li><a>number</a>,</li>
-        <li><a>true</a>,</li>
-        <li><a>false</a>,</li>
+        <li><code>true</code>,</li>
+        <li><code>false</code>,</li>
         <li><a>null</a>,</li>
         <li><a>node object</a>,</li>
         <li><a>value object</a>, or</li>
@@ -11939,7 +11939,7 @@ the data type to be specified explicitly with each piece of data.</p>
     </dd>
     <dt><code>@value</code></dt><dd>
       The <code>@value</code> keyword MAY be aliased and MUST be used as a key in a <a>value object</a>.
-      Its value key MUST be either a <a>string</a>, a <a>number</a>, <a>true</a>, <a>false</a> or <a>null</a>.
+      Its value key MUST be either a <a>string</a>, a <a>number</a>, <code>true</code>, <code>false</code> or <a>null</a>.
       This keyword is described further in <a class="sectionRef" href="#value-objects"></a>.
     </dd>
     <dt><code>@version</code></dt><dd>
@@ -11984,8 +11984,8 @@ the data type to be specified explicitly with each piece of data.</p>
       (<a>typed values</a>) or
       <a>language-tagged strings</a> whereas
       JSON-LD also supports JSON's native data types, i.e., <a>number</a>,
-      <a>strings</a>, and the boolean values <a>true</a>
-      and <a>false</a>. The JSON-LD 1.1 Processing Algorithms and API specification [[JSON-LD11-API]]
+      <a>strings</a>, and the boolean values <code>true</code>
+      and <code>false</code>. The JSON-LD 1.1 Processing Algorithms and API specification [[JSON-LD11-API]]
       defines the <a data-cite="JSON-LD11-API#data-round-tripping">conversion rules</a>
       between JSON's native data types and RDF's counterparts to allow round-tripping.</li>
   </ul>
@@ -12390,7 +12390,7 @@ the data type to be specified explicitly with each piece of data.</p>
         counterparts. <a>Numbers</a> without fractions are
         converted to <code>xsd:integer</code>-typed literals, numbers with fractions
         to <code>xsd:double</code>-typed literals and the two boolean values
-        <a>true</a> and <a>false</a> to a <code>xsd:boolean</code>-typed
+        <code>true</code> and <code>false</code> to a <code>xsd:boolean</code>-typed
         literal. All typed literals are in canonical lexical form.</p>
 
       <pre class="example" data-transform="updateExample"
@@ -12825,7 +12825,7 @@ the data type to be specified explicitly with each piece of data.</p>
       when compacting only if
       a <a>simple term definition</a> is used where the value ends with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
       or if their <a>expanded term definition</a> contains
-      a <code>@prefix</code> <a>member</a> with the value <a>true</a>. The 1.0 algorithm has
+      a <code>@prefix</code> <a>member</a> with the value <code>true</code>. The 1.0 algorithm has
       been updated to only consider terms that map to a value that ends with a URI
       <a data-cite="RFC3986#section-2.2">gen-delim</a> character.</li>
     <li>Values of properties where the associated <a>term definition</a>

--- a/index.html
+++ b/index.html
@@ -3,11 +3,10 @@
 <head>
 <title>JSON-LD 1.1</title>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
-<script type="text/javascript" src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer></script>
-<script type="text/javascript" src="common/common.js" class="remove" defer></script>
-<script type="text/javascript" src="common/jsonld.js" class="remove"></script>
-<script type="text/javascript" class="remove">
-//<![CDATA[
+<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer></script>
+<script src="common/common.js" class="remove" defer></script>
+<script src="common/jsonld.js" class="remove"></script>
+<script class="remove">
   var respecConfig = {
       // extend the bibliography entries
       localBiblio:            jsonld.localBiblio,
@@ -118,7 +117,6 @@
       maxTocLevel: 4
       ///alternateFormats: [ {uri: "diff-20140116.html", label: "diff to previous version"} ]
   };
-//]]>
 </script>
 <script>
   // Add example button selection logic
@@ -278,9 +276,9 @@
       <a href="https://www.w3.org/2018/json-ld-wg/">JSON-LD Working Group</a>:</p>
 
     <ul>
-      <li><a data-cite="JSON-LD11">JSON-LD 1.1</a></li>
-      <li><a data-cite="JSON-LD11-API">JSON-LD 1.1 Processing Algorithms and API</a></li>
-      <li><a data-cite="JSON-LD11-FRAMING">JSON-LD 1.1 Framing</a></li>
+      <li><a href="">JSON-LD 1.1</a></li>
+      <li>[[[JSON-LD11-API]]]</li>
+      <li>[[[JSON-LD11-FRAMING]]]</li>
     </ul>
   </section>
 </section>
@@ -355,7 +353,7 @@
       providing a standard library interface for common JSON-LD operations.</p>
 
     <p>To understand the basics in this specification you must first be familiar with
-      <a data-cite="RFC8259">JSON</a>, which is detailed in [[RFC8259]].</p>
+      <a data-cite="RFC8259" data-no-xref="">JSON</a>, which is detailed in [[RFC8259]].</p>
 
     <p>This document almost exclusively uses the term IRI
     (<a data-cite="ld-glossary#internationalized-resource-identifier">Internationalized Resource Indicator</a>)
@@ -480,7 +478,7 @@
       section <a href="#relationship-to-rdf"></a>.</p>
 
     <p>At the surface level, a <a>JSON-LD document</a> is simply
-      <a data-cite="RFC8259">JSON</a>, detailed in [[RFC8259]].
+      <a data-cite="RFC8259" data-no-xref="">JSON</a>, detailed in [[RFC8259]].
       For the purpose of describing the core data structures,
       this is limited to <a>arrays</a>, <a>dictionaries</a> (the parsed version of a <a>JSON Object</a>),
       <a>strings</a>, <a>numbers</a>, <a>booleans</a>, and <a>null</a>,
@@ -489,8 +487,8 @@
         to be manipulated using the same algorithms, when the syntax maps
         to equivalent core data structures</span>.</p>
       <p class="changed note">Although not discussed in this specification,
-        parallel work using <a data-cite="YAML">YAML</a> [[YAML]]
-        and binary representations such as <a data-cite="RFC7049">CBOR</a> [[RFC7049]]
+        parallel work using [[[YAML]]] [[YAML]]
+        and binary representations such as [[[RFC7049]]] [[RFC7049]]
         could be used to map into the <a>internal representation</a>, allowing
         the JSON-LD 1.1 API [[JSON-LD11-API]] to operate as if the source was a
         JSON document.</p>
@@ -582,7 +580,7 @@
         when compacting.</dd>
       <dt class="changed"><code>@version</code></dt><dd class="changed">
         Used in a <a>context definition</a> to set the <a>processing mode</a>.
-        New features since <a data-cite="JSON-LD">JSON-LD 1.0</a> [[JSON-LD]] described in this specification are
+        New features since [[[JSON-LD]]] [[JSON-LD]] described in this specification are
         only available when <a>processing mode</a> has been explicitly set to
         <code>json-ld-1.1</code>.
       </dd>
@@ -1066,7 +1064,7 @@
     the primary distinction is that a URL <em>locates</em> a resource on the web,
     an IRI <em>identifies</em> a resource. While it is a good practice for resource identifiers
     to be dereferenceable, sometimes this is not practical. In particular, note the
-    [[URN]] scheme for Uniform Resource Names, such as <a data-cite="rfc4122">UUID</a>.
+    [[URN]] scheme for Uniform Resource Names, such as <a data-cite="rfc4122" data-no-xref="">UUID</a>.
     An example UUID is <code>urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6</code>.</p>
 
   <p class="note"><a>Properties</a>, values of <code>@type</code>,
@@ -2254,7 +2252,7 @@
     the former will be interpreted as having had <code>"@version": 1.1</code> defined within it.</p>
 
   <p class="note">Setting the <a>processing mode</a> explicitly
-    for JSON-LD 1.1 is necessary so that a JSON-LD 1.0 processor
+    for JSON-LD 1.1 is necessary so that a [[[JSON-LD]]] processor
     does not attempt to process a JSON-LD 1.1 document and silently
     produce different results.</p>
 </section>
@@ -2779,7 +2777,7 @@
   </aside>
 
   <p class="changed">When operating with the default <a>processing mode</a>
-    for JSON-LD 1.0 compatibility, terms may be chosen as <a>compact IRI</a> prefixes when
+    for [[[JSON-LD]]] compatibility, terms may be chosen as <a>compact IRI</a> prefixes when
     compacting only if a <a>simple term definition</a> is used where the value ends with a
     URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character (e.g, <code>/</code>,
     <code>#</code> and others, see [[RFC3986]]).</p>
@@ -2791,7 +2789,7 @@
     a <code>@prefix</code> <a>member</a> with the value <a>true</a>.</p>
 
   <p class="note changed">The term selection behavior for 1.0 processors was changed
-    as a result of an errata against JSON-LD 1.0 reported <a href="https://lists.w3.org/Archives/Public/public-rdf-comments/2018Jan/0002.html">here</a>.
+    as a result of an errata against [[[JSON-LD]]] reported <a href="https://lists.w3.org/Archives/Public/public-rdf-comments/2018Jan/0002.html">here</a>.
     This does not affect the behavior of processing existing JSON-LD documents, but creates
     a slight change when compacting documents using <a>Compact IRIs</a>.</p>
 
@@ -5313,7 +5311,7 @@ the data type to be specified explicitly with each piece of data.</p>
   fully supported.</p>
 
 <p class="changed">Note that the <code>"@container": "@list"</code> definition recursively
-  describes array values of lists as being, themselves, lists. For example, in <a data-cite="RFC7946">GeoJSON</a> (see [[RFC7946]]),
+  describes array values of lists as being, themselves, lists. For example, in [[[RFC7946]]] (see [[RFC7946]]),
   <em>coordinates</em> are an ordered list of <em>positions</em>, which are
   represented as an array of two or more numbers:</p>
 
@@ -12237,7 +12235,7 @@ the data type to be specified explicitly with each piece of data.</p>
     the base direction of the string.</p>
 
   <p>Unicode provides a mechanism for signaling direction within a string
-    (see <a data-cite="UAX9">Unicode Bidirectional Algorithm</a> [[UAX9]]),
+    (see [[[UAX9]]] [[UAX9]]),
     however, when a string has an overall base direction which cannot be determined by the
     beginning of the string, an external indicator is required,
     such as the [[HTML]] <a data-cite="HTML/dom.html#the-dir-attribute">dir attribute</a>,
@@ -12816,7 +12814,7 @@ the data type to be specified explicitly with each piece of data.</p>
       to JSON.</li>
     <li>Added <a href="#node-identifier-indexing" class="sectionRef"></a> and <a href="#node-type-indexing" class="sectionRef"></a>.</li>
     <li>Both <a>language maps</a> and <a>index maps</a> may legitimately have an <code>@none</code> key, but
-      JSON-LD 1.0 only allowed <a>string</a> keys. This has been updated
+      [[[JSON-LD]]] only allowed <a>string</a> keys. This has been updated
       to allow <code>@none</code> keys.</li>
     <li>The value for <code>@container</code> in an <a>expanded term definition</a>
       can also be an <a>array</a> containing any appropriate container

--- a/index.html
+++ b/index.html
@@ -9972,7 +9972,7 @@ the data type to be specified explicitly with each piece of data.</p>
 
   <section class="informative"><h3>Representing Singular Values as Arrays</h3>
     <p>Generally, when compacting, properties having only one value are
-      represented as strings or <p>maps</p>, while properties having
+      represented as strings or <a>maps</a>, while properties having
       multiple values are represented as an array of strings or <a>maps</a>.
       This means that applications accessing such properties need to be prepared
       to accept either representation. To force all values to be represented

--- a/index.html
+++ b/index.html
@@ -862,10 +862,10 @@
       either be a simple string, mapping the <a>term</a> to an <a>IRI</a>,
       or a <a>map</a>.</p>
 
-    <p>A <a>context</a> is introduced using a <a>entry</a> with the key <code>@context</code> and may
+    <p>A <a>context</a> is introduced using an <a>entry</a> with the key <code>@context</code> and may
       appear within a <a>node object</a> or a <a>value object</a>.</p>
 
-    <p>When a <a>entry</a> with a <a>term</a> key has a <a>map</a> value, the <a>map</a> is called
+    <p>When an <a>entry</a> with a <a>term</a> key has a <a>map</a> value, the <a>map</a> is called
       an <a>expanded term definition</a>. The example above specifies that
       the values of <code>image</code> and <code>homepage</code>, if they are
       strings, are to be interpreted as
@@ -3531,7 +3531,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     To prevent this divergence of interpretation,
     JSON-LD 1.1 allows term definitions to be <em>protected</em>.
     </p>
-  <p>A <dfn>protected term definition</dfn> is a term definition with a <a>entry</a> <code>@protected</code> set to <code>true</code>.
+  <p>A <dfn>protected term definition</dfn> is a term definition with an <a>entry</a> <code>@protected</code> set to <code>true</code>.
     It generally prevents further contexts from overriding this term definition,
     either through a new definition of the same term,
     or through clearing the context with <code>"@context": null</code>.
@@ -3575,10 +3575,10 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
   </pre>
 
   <p>When all or most term definitions of a context need to be protected,
-    it is possible to add a <a>entry</a> <code>@protected</code> set to <code>true</code>
+    it is possible to add an <a>entry</a> <code>@protected</code> set to <code>true</code>
     to the context itself.
     It has the same effect as protecting each of its term definitions individually.
-    Exceptions can be made by adding a <a>entry</a> <code>@protected</code> set to <code>false</code>
+    Exceptions can be made by adding an <a>entry</a> <code>@protected</code> set to <code>false</code>
     in some term definitions.
     </p>
 
@@ -11370,7 +11370,7 @@ the data type to be specified explicitly with each piece of data.</p>
         an <a>array</a> containing only an empty <a>map</a>,
         an empty <a>array</a> (<a data-cite="JSON-LD11-FRAMING#dfn-match-none">match none</a>)
         an <a>array</a> of <a>IRIs</a>.</li>
-      <li>A <a>frame object</a> MAY include a <a>entry</a> with the key <code>@embed</code> with
+      <li>A <a>frame object</a> MAY include an <a>entry</a> with the key <code>@embed</code> with
         any value from <code>@always</code>, <code>@list</code>, and <code>@never</code>.</li>
       <li>A <a>frame object</a> MAY include <a>entries</a> with the boolean valued
         keys <code>@explicit</code>, <code>@omitDefault</code>, or <code>@requireAll</code></li>

--- a/index.html
+++ b/index.html
@@ -480,7 +480,7 @@
     <p>At the surface level, a <a>JSON-LD document</a> is simply
       <a data-cite="RFC8259" data-no-xref="">JSON</a>, detailed in [[RFC8259]].
       For the purpose of describing the core data structures,
-      this is limited to <a>arrays</a>, <a>dictionaries</a> (the parsed version of a <a>JSON Object</a>),
+      this is limited to <a>arrays</a>, <a>maps</a> (the parsed version of a <a>JSON Object</a>),
       <a>strings</a>, <a>numbers</a>, <a>booleans</a>, and <a>null</a>,
       <span class="changed">called the <a>JSON-LD internal representation</a>.
         This allows surface syntaxes other than JSON
@@ -573,7 +573,7 @@
       <dt class="changed"><code>@nest</code></dt><dd class="changed">Collects a set of <a>nested properties</a> within
         a <a>node object</a>.</dd>
       <dt class="changed"><code>@none</code></dt><dd class="changed">Used as an index value
-        in an <a>index map</a>, <a>id map</a>, <a>language map</a>, <a>type map</a>, or elsewhere where a dictionary is
+        in an <a>index map</a>, <a>id map</a>, <a>language map</a>, <a>type map</a>, or elsewhere where a <a>map</a> is
         used to index into other values.</dd>
       <dt class="changed"><code>@prefix</code></dt><dd class="changed">
         With the value <code>true</code>, allows this <a>term</a> to be used to construct a <a>compact IRI</a>
@@ -860,12 +860,12 @@
 
     <p>As the <a>context</a> above shows, the value of a <a>term definition</a> can
       either be a simple string, mapping the <a>term</a> to an <a>IRI</a>,
-      or a <a>dictionary</a>.</p>
+      or a <a>map</a>.</p>
 
-    <p>A <a>context</a> is introduced using a <a>member</a> with the key <code>@context</code> and may
+    <p>A <a>context</a> is introduced using a <a>entry</a> with the key <code>@context</code> and may
       appear within a <a>node object</a> or a <a>value object</a>.</p>
 
-    <p>When a <a>member</a> with a <a>term</a> key has a <a>dictionary</a> value, the <a>dictionary</a> is called
+    <p>When a <a>entry</a> with a <a>term</a> key has a <a>map</a> value, the <a>map</a> is called
       an <a>expanded term definition</a>. The example above specifies that
       the values of <code>image</code> and <code>homepage</code>, if they are
       strings, are to be interpreted as
@@ -1074,7 +1074,7 @@
     <a>vocabulary mapping</a>, and not the <a>base IRI</a>.</p>
 
   <p>A <a>string</a> is interpreted as an <a>IRI</a> when it is the
-    value of a <a>dictionary member</a> with the key <code>@id</code>:</p>
+    value of a <a>map entry</a> with the key <code>@id</code>:</p>
 
   <pre class="example nohighlight" data-transform="updateExample"
        title="Values of @id are interpreted as IRI">
@@ -1252,7 +1252,7 @@
     different ways in JSON-LD:</p>
 
   <ol>
-    <li><a>Dictionary members</a> that have a key mapping to a <a>term</a> in
+    <li><a>Map entries</a> that have a key mapping to a <a>term</a> in
       the <a>active context</a> expand to an <a>IRI</a>
       (only applies outside of the <a>context definition</a>).</li>
     <li>An <a>IRI</a> is generated for the <a>string</a> value specified using
@@ -1356,7 +1356,7 @@
     <li><a>Boolean</a> <code>true</code> and <code>false</code>, which describe literal boolean values,</li>
     <li><code>null</code>, which describes the absense of a value,</li>
     <li><a>Arrays</a>, which describe an ordered set of values of any type, and</li>
-    <li><a>JSON objects</a>, which provide a set of <a>dictionary members</a>, relating keys with values.</li>
+    <li><a>JSON objects</a>, which provide a set of <a>map entries</a>, relating keys with values.</li>
   </ul>
 
   <p>The JSON-LD data model allows for a richer set of resources, based on the RDF data model.
@@ -1382,7 +1382,7 @@
     </dd>
     <dt><a>List Objects</a> and <a>Set objects</a></dt><dd></dd>
     <dt>Map Objects</dt><dd>
-      JSON-LD uses various forms of <a>dictionaries</a> as ways to more easily access values of a <a>property</a>.
+      JSON-LD uses various forms of <a>maps</a> as ways to more easily access values of a <a>property</a>.
       <dl>
         <dt><a>Language Maps</a></dt><dd>
           Allows multiple values differing in their associated language to be
@@ -1834,7 +1834,7 @@
   be achieved using JSON-LD.</p>
 
   <p>In general, contexts may be used any time a
-    <a>dictionary</a> is defined.
+    <a>map</a> is defined.
     The only time that one cannot express a context is as a direct child of another context definition (other than as part of an <a>expanded term definition</a>).
     For example, a <a>JSON-LD document</a> may
     have the form of an <a>array</a> composed of one or more <a>node objects</a>,
@@ -1944,7 +1944,7 @@
     and <a>flattened document form</a>,
     and may be necessary when describing a disconnected graph,
     where nodes may not reference each other. In such cases, using
-    a top-level dictionary with a <code>@graph</code> property can be useful for saving
+    a top-level <a>map</a> with a <code>@graph</code> property can be useful for saving
     the repetition of <code>@context</code>. See <a href="#embedding" class="sectionRef"></a>
     for more.</p>
 
@@ -2126,14 +2126,14 @@
     Note that this is
     rarely a good authoring practice and is typically used when working with
     legacy applications that depend on a specific structure of the
-    <a>dictionary</a>. If a <a>term</a> is redefined within a
+    <a>map</a>. If a <a>term</a> is redefined within a
     context, all previous rules associated with the previous definition are
     removed. If a <a>term</a> is redefined to <code>null</code>,
     the <a>term</a> is effectively removed from the list of
     <a>terms</a> defined in the <a>active context</a>.</p>
 
   <p>Multiple contexts may be combined using an <a>array</a>, which is processed
-    in order. The set of contexts defined within a specific <a>dictionary</a> are
+    in order. The set of contexts defined within a specific <a>map</a> are
     referred to as <a>local contexts</a>. The
     <a>active context</a> refers to the accumulation of
     <a>local contexts</a> that are in scope at a
@@ -2228,7 +2228,7 @@
 
   <p>New features defined in JSON-LD 1.1 are available
     when the <a>processing mode</a> is set to <code>json-ld-1.1</code>.
-    This may be set using the <code>@version</code> <a>member</a> in a <code>context</code>
+    This may be set using the <code>@version</code> <a>entry</a> in a <code>context</code>
     set to the value <code>1.1</code> as a <a>number</a>, or through an API option.</p>
 
   <pre class="example nohighlight" data-transform="updateExample"
@@ -2322,10 +2322,10 @@
   </aside>
 
   <p>If <code>@vocab</code> is used but certain keys in an
-    <a>dictionary</a> should not be expanded using
+    <a>map</a> should not be expanded using
     the vocabulary <a>IRI</a>, a <a>term</a> can be explicitly set
     to <a>null</a> in the <a>context</a>. For instance, in the
-    example below the <code>databaseId</code> <a>member</a> would not expand to an
+    example below the <code>databaseId</code> <a>entry</a> would not expand to an
     <a>IRI</a> causing the property to be dropped when expanding.</p>
 
   <aside class="example ds-selector-tabs"
@@ -2786,7 +2786,7 @@
     when compacting only if
     a <a>simple term definition</a> is used where the value ends with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
     or if their <a>expanded term definition</a> contains
-    a <code>@prefix</code> <a>member</a> with the value <code>true</code>.</p>
+    a <code>@prefix</code> <a>entry</a> with the value <code>true</code>.</p>
 
   <p class="note changed">The term selection behavior for 1.0 processors was changed
     as a result of an errata against [[[JSON-LD]]] reported <a href="https://lists.w3.org/Archives/Public/public-rdf-comments/2018Jan/0002.html">here</a>.
@@ -3531,7 +3531,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     To prevent this divergence of interpretation,
     JSON-LD 1.1 allows term definitions to be <em>protected</em>.
     </p>
-  <p>A <dfn>protected term definition</dfn> is a term definition with a member <code>@protected</code> set to <code>true</code>.
+  <p>A <dfn>protected term definition</dfn> is a term definition with a <a>entry</a> <code>@protected</code> set to <code>true</code>.
     It generally prevents further contexts from overriding this term definition,
     either through a new definition of the same term,
     or through clearing the context with <code>"@context": null</code>.
@@ -3575,10 +3575,10 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
   </pre>
 
   <p>When all or most term definitions of a context need to be protected,
-    it is possible to add a member <code>@protected</code> set to <code>true</code>
+    it is possible to add a <a>entry</a> <code>@protected</code> set to <code>true</code>
     to the context itself.
     It has the same effect as protecting each of its term definitions individually.
-    Exceptions can be made by adding a member <code>@protected</code> set to <code>false</code>
+    Exceptions can be made by adding a <a>entry</a> <code>@protected</code> set to <code>false</code>
     in some term definitions.
     </p>
 
@@ -4100,7 +4100,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
   (<code>http://www.w3.org/2001/XMLSchema#dateTime</code>) with the
   value expressed using the <code>@value</code> <a>keyword</a>. As a
   general rule, when <code>@value</code> and <code>@type</code> are used in
-  the same <a>dictionary</a>, the <code>@type</code>
+  the same <a>map</a>, the <code>@type</code>
   <a>keyword</a> is expressing a <a>value type</a>.
   Otherwise, the <code>@type</code> <a>keyword</a> is expressing a
   <a>node type</a>. The example above expresses the following data:</p>
@@ -4405,7 +4405,7 @@ the data type to be specified explicitly with each piece of data.</p>
 </aside>
 
 <p>It is important to note that <a>terms</a> are only used in expansion
-  for vocabulary-relative positions, such as for keys and values of <a>dictionary members</a>.
+  for vocabulary-relative positions, such as for keys and values of <a>map entries</a>.
   Values of <code>@id</code> are considered to be document-relative,
   and do not use term definitions for expansion. For example, consider the following:</p>
 
@@ -5677,7 +5677,7 @@ the data type to be specified explicitly with each piece of data.</p>
 <section class="informative changed"><h2>Using <code>@set</code> with <code>@type</code></h2>
   <p class="changed">When <a>processing mode</a> is set to <code>json-ld-1.1</code>,
     <code>@type</code> may be used with an <a>expanded term definition</a> with <code>@container</code> set
-    to <code>@set</code>; no other members may be set within such an <a>expanded term definition</a>.
+    to <code>@set</code>; no other <a>entries</a> may be set within such an <a>expanded term definition</a>.
     This is used by the <a data-cite="JSON-LD11-API#compaction-algorithm">Compaction algorithm</a> to ensure that the values of <code>@type</code> (or an alias)
     are always represented in an <a>array</a>.</p>
 
@@ -6474,7 +6474,7 @@ the data type to be specified explicitly with each piece of data.</p>
 
 <p>Sometimes multiple property values need to be accessed
   in a more direct fashion than iterating though multiple array values. JSON-LD
-  provides an indexing mechanism to allow the use of an intermediate dictionary
+  provides an indexing mechanism to allow the use of an intermediate <a>map</a>
   to associate specific indexes with associated values.</p>
 
 <dl>
@@ -8436,7 +8436,7 @@ the data type to be specified explicitly with each piece of data.</p>
     which specifies when the graph was generated.</p>
 
   <p>When a JSON-LD document's top-level structure is an
-    <a>dictionary</a> that contains no other
+    <a>map</a> that contains no other
     keys than <code>@graph</code> and
     optionally <code>@context</code> (properties that are not mapped to an
     <a>IRI</a> or a <a>keyword</a> are ignored),
@@ -9863,7 +9863,7 @@ the data type to be specified explicitly with each piece of data.</p>
       }
       -->
       </pre>
-      <p>The compacted version uses a <a>dictionary</a> value
+      <p>The compacted version uses a <a>map</a> value
         for "label", with the keys representing the <a>language tag</a>
         and the values are the <a>strings</a> associated with the relevant <a>language tag</a>.</p>
       <pre class="compacted" data-transform="updateExample"
@@ -9972,8 +9972,8 @@ the data type to be specified explicitly with each piece of data.</p>
 
   <section class="informative"><h3>Representing Singular Values as Arrays</h3>
     <p>Generally, when compacting, properties having only one value are
-      represented as strings or dictionaries, while properties having
-      multiple values are represented as an array of strings or dictionaries.
+      represented as strings or <p>maps</p>, while properties having
+      multiple values are represented as an array of strings or <a>maps</a>.
       This means that applications accessing such properties need to be prepared
       to accept either representation. To force all values to be represented
       using an array, a term definition can set <code>"@container": "@set"</code>.
@@ -10009,7 +10009,7 @@ the data type to be specified explicitly with each piece of data.</p>
       }
       -->
       </pre>
-      <p>The compacted version uses a <a>dictionary</a> value
+      <p>The compacted version uses a <a>map</a> value
         for "label" as before.
         and the values are the relevant <a>strings</a> but always represented using an <a>array</a>.</p>
       <pre class="compacted result" data-transform="updateExample"
@@ -10119,7 +10119,7 @@ the data type to be specified explicitly with each piece of data.</p>
   <p>The JSON-LD 1.1 Processing Algorithms and API specification [[JSON-LD11-API]] defines
     a method for <em>flattening</em> a JSON-LD document.
     <dfn data-cite="JSON-LD11-API#dfn-flattened" data-lt="flattened">Flattening</dfn> collects all
-    properties of a <a>node</a> in a single <a>dictionary</a> and labels
+    properties of a <a>node</a> in a single <a>map</a> and labels
     all <a>blank nodes</a> with
     <a>blank node identifiers</a>.
     This ensures a shape of the data and consequently may drastically simplify the code
@@ -10349,7 +10349,7 @@ the data type to be specified explicitly with each piece of data.</p>
   </ul>
 
   <p>The referenced document MUST have a top-level <a>JSON object</a>.
-    The <code>@context</code> <a>member</a> within that object is added to the top-level
+    The <code>@context</code> <a>entry</a> within that object is added to the top-level
     <a>JSON object</a> of the referencing document. If an <a>array</a>
     is at the top-level of the referencing document and its items are
     <a>JSON objects</a>, the <code>@context</code>
@@ -11024,7 +11024,7 @@ the data type to be specified explicitly with each piece of data.</p>
 
   <p class="changed">Additionally, the JSON serialization format is internally represented using
     the <a>JSON-LD internal representation</a>, which uses the generic
-    concepts of <a>arrays</a>, <a>dictionaries</a>,
+    concepts of <a>lists</a>, <a>maps</a>,
     <a>strings</a>, <a>numbers</a>, <a>booleans</a>, and <a>null</a> to describe
     the data represented by a JSON document.</p>
 
@@ -11190,8 +11190,8 @@ the data type to be specified explicitly with each piece of data.</p>
       valid <a data-cite="RFC8259#section-2">JSON text</a></span>.</p>
 
   <p>A <a>JSON-LD document</a> MUST be a single <a>node object</a>,
-    a <a>dictionary</a> consisting of only
-    the <a>members</a> <code>@context</code> and/or <code>@graph</code>,
+    a <a>map</a> consisting of only
+    the <a>entries</a> <code>@context</code> and/or <code>@graph</code>,
     or an <a>array</a> of zero or more <a>node objects</a>.</p>
 
   <p>In contrast to JSON, in JSON-LD the keys in <a data-lt="JSON object">objects</a>
@@ -11241,13 +11241,13 @@ the data type to be specified explicitly with each piece of data.</p>
 
     <p>A <a>node object</a> represents zero or more properties of a
       <a>node</a> in the <a>graph</a> serialized by the
-      <a>JSON-LD document</a>. A <a>dictionary</a> is a
+      <a>JSON-LD document</a>. A <a>map</a> is a
       <a>node object</a> if it exists outside of a JSON-LD
       <a>context</a> and:</p>
 
     <ul>
-      <li>it is not the top-most <a>dictionary</a> in the JSON-LD document consisting
-        of no other <a>members</a> than <code>@graph</code> and <code>@context</code>,</li>
+      <li>it is not the top-most <a>map</a> in the JSON-LD document consisting
+        of no other <a>entries</a> than <code>@graph</code> and <code>@context</code>,</li>
       <li>it does not contain the <code>@value</code>, <code>@list</code>,
         or <code>@set</code> keywords, and</li>
       <li class="changed">it is not a <a>graph object</a>.</li>
@@ -11260,7 +11260,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <a>node objects</a> need to be merged to create the
       properties of the resulting <a>node</a>.</p>
 
-    <p>A <a>node object</a> MUST be a <a>dictionary</a>. All keys
+    <p>A <a>node object</a> MUST be a <a>map</a>. All keys
       which are not <a>IRIs</a>, <a>compact IRIs</a>, <a>terms</a> valid in the
       <a>active context</a>, or one of the following <a>keywords</a>
       <span class="changed">(or alias of such a keyword)</span>
@@ -11297,10 +11297,10 @@ the data type to be specified explicitly with each piece of data.</p>
       If the <a>node object</a> also contains an <code>@id</code> keyword,
       its value is used as the <a>graph name</a> of a <a>named graph</a>.
       See <a class="sectionRef" href="#named-graphs"></a> for further discussion on
-      <code>@graph</code> values. As a special case, if a <a>dictionary</a>
+      <code>@graph</code> values. As a special case, if a <a>map</a>
       contains no keys other than <code>@graph</code> and <code>@context</code>, and the
-      <a>dictionary</a> is the root of the JSON-LD document, the
-      <a>dictionary</a> is not treated as a <a>node object</a>; this
+      <a>map</a> is the root of the JSON-LD document, the
+      <a>map</a> is not treated as a <a>node object</a>; this
       is used as a way of defining <a>node objects</a>
       that may not form a connected graph. This allows a
       <a>context</a> to be defined which is shared by all of the constituent
@@ -11316,7 +11316,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <code>@type</code> values.</p>
 
     <p>If the <a>node object</a> contains the <code>@reverse</code> key,
-      its value MUST be a <a>dictionary</a> containing <a>members</a> representing reverse
+      its value MUST be a <a>map</a> containing <a>entries</a> representing reverse
       properties. Each value of such a reverse property MUST be an <a>absolute IRI</a>,
       a <a>relative IRI</a>, a <a>compact IRI</a>, a <a>blank node identifier</a>,
       a <a>node object</a> or an <a>array</a> containing a combination of these.</p>
@@ -11327,7 +11327,7 @@ the data type to be specified explicitly with each piece of data.</p>
       on <code>@index</code> values.</p>
 
     <p class="changed">If the <a>node object</a> contains the <code>@nest</code> key,
-      its value MUST be a <a>dictionary</a> or an <a>array</a> of <a>dictionaries</a>
+      its value MUST be a <a>map</a> or an <a>array</a> of <a>map</a>
       which MUST NOT include a <a>value object</a>. See
       <a class="sectionRef" href="#property-nesting"></a> for further discussion
       on <code>@nest</code> values.</p>
@@ -11358,21 +11358,21 @@ the data type to be specified explicitly with each piece of data.</p>
 
   <section class="normative"><h2>Frame Objects</h2>
     <p>When <a>framing</a>, a <a>frame object</a> extends a <a>node object</a> to allow
-      members used specifically for <a>framing</a>.</p>
+      <a>entries</a> used specifically for <a>framing</a>.</p>
     <ul>
       <li>A <a>frame object</a> MAY include a <a>default object</a> as the value of any key
         which is not a <a>keyword</a>.
         Values of <code>@default</code> MAY include the value <code>@null</code>,
         or an <a>array</a> containing only <code>@null</code>, in addition to other values
-        allowed in the grammar for values of <a>member</a> keys expanding to <a>absolute IRIs</a>.</li>
+        allowed in the grammar for values of <a>entry</a> keys expanding to <a>absolute IRIs</a>.</li>
       <li>The values of <code>@id</code> and <code>@type</code> MAY additionally be
-        an empty <a>dictionary</a> (<a data-cite="JSON-LD11-FRAMING#dfn-wildcard">wildcard</a>),
-        an <a>array</a> containing only an empty <a>dictionary</a>,
+        an empty <a>map</a> (<a data-cite="JSON-LD11-FRAMING#dfn-wildcard">wildcard</a>),
+        an <a>array</a> containing only an empty <a>map</a>,
         an empty <a>array</a> (<a data-cite="JSON-LD11-FRAMING#dfn-match-none">match none</a>)
         an <a>array</a> of <a>IRIs</a>.</li>
-      <li>A <a>frame object</a> MAY include a <a>member</a> with the key <code>@embed</code> with
+      <li>A <a>frame object</a> MAY include a <a>entry</a> with the key <code>@embed</code> with
         any value from <code>@always</code>, <code>@list</code>, and <code>@never</code>.</li>
-      <li>A <a>frame object</a> MAY include <a>members</a> with the boolean valued
+      <li>A <a>frame object</a> MAY include <a>entries</a> with the boolean valued
         keys <code>@explicit</code>, <code>@omitDefault</code>, or <code>@requireAll</code></li>
       <li>In addition to other property values, a property of a <a>frame object</a>
         MAY include a <a data-cite="JSON-LD11-FRAMING#dfn-value-pattern">value pattern</a>
@@ -11386,11 +11386,11 @@ the data type to be specified explicitly with each piece of data.</p>
 
     <p>A <a>graph object</a> represents a <a>named graph</a>, which MAY include
       an explicit <a>graph name</a>.
-      A <a>dictionary</a> is a <a>graph object</a> if
+      A <a>map</a> is a <a>graph object</a> if
       it exists outside of a JSON-LD <a>context</a>,
-      it contains an <code>@graph</code> member (or an alias of that <a>keyword</a>),
-      it is not the top-most <a>dictionary</a> in the JSON-LD document, and
-      it consists of no <a>members</a> other than <code>@graph</code>,
+      it contains an <code>@graph</code> <a>entry</a> (or an alias of that <a>keyword</a>),
+      it is not the top-most <a>map</a> in the JSON-LD document, and
+      it consists of no <a>entries</a> other than <code>@graph</code>,
       <code>@index</code>, <code>@id</code>
       and <code>@context</code>, or an alias of one of these <a>keywords</a>.</p>
 
@@ -11409,7 +11409,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <a class="sectionRef" href="#identifying-blank-nodes"></a> for further discussion on
       <code>@id</code> values.</p>
 
-    <p>A <a>graph object</a> without an <code>@id</code> <a>member</a> is also a
+    <p>A <a>graph object</a> without an <code>@id</code> <a>entry</a> is also a
       <a>simple graph object</a> and represents a <a>named graph</a> without an
       explicit identifier, although in the data model it still has a
       <a>graph name</a>, which is an implicitly allocated
@@ -11429,7 +11429,7 @@ the data type to be specified explicitly with each piece of data.</p>
       language with a value to create a <a>typed value</a> or a <a>language-tagged
       string</a>.</p>
 
-    <p>A <a>value object</a> MUST be a <a>dictionary</a> containing the
+    <p>A <a>value object</a> MUST be a <a>map</a> containing the
       <code>@value</code> key. It MAY also contain an <code>@type</code>,
       an <code>@language</code>, an <code>@index</code>, or an <code>@context</code> key but MUST NOT contain
       both an <code>@type</code> and an <code>@language</code> key at the same time.
@@ -11466,11 +11466,11 @@ the data type to be specified explicitly with each piece of data.</p>
     <p>When <a>framing</a>,
       a <a data-cite="JSON-LD11-FRAMING#dfn-value-pattern">value pattern</a>
       extends a <a>value object</a> to allow
-      members used specifically for <a>framing</a>.</p>
+      <a>entries</a> used specifically for <a>framing</a>.</p>
     <ul>
       <li>The values of <code>@value</code>, <code>@language</code> and <code>@type</code> MAY additionally be
-        an empty <a>dictionary</a> (<a data-cite="JSON-LD11-FRAMING#dfn-wildcard">wildcard</a>),
-        an <a>array</a> containing only an empty <a>dictionary</a>,
+        an empty <a>map</a> (<a data-cite="JSON-LD11-FRAMING#dfn-wildcard">wildcard</a>),
+        an <a>array</a> containing only an empty <a>map</a>,
         an empty <a>array</a> (<a data-cite="JSON-LD11-FRAMING#dfn-match-none">match none</a>)
         an <a>array</a> of <a>strings</a>.</li>
     </ul>
@@ -11492,11 +11492,11 @@ the data type to be specified explicitly with each piece of data.</p>
       This simplifies post-processing of the data as the data is always in a
       deterministic form.</p>
 
-    <p>A <a>list object</a> MUST be a <a>dictionary</a> that contains no
+    <p>A <a>list object</a> MUST be a <a>map</a> that contains no
       keys that expand to an <a>absolute IRI</a> or <a>keyword</a> other
       than <code>@list</code> and <code>@index</code>.</p>
 
-    <p>A <a>set object</a> MUST be a <a>dictionary</a> that contains no
+    <p>A <a>set object</a> MUST be a <a>map</a> that contains no
       keys that expand to an <a>absolute IRI</a> or <a>keyword</a> other
       than <code>@set</code> and <code>@index</code>.
       Please note that the <code>@index</code> key will be ignored when being processed.</p>
@@ -11553,7 +11553,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <span class="changed">
         or an array containing both <code>@index</code> and <code>@set</code>
       </span>.
-      The values of the <a>members</a> of an <a>index map</a> MUST be one
+      The values of the <a>entries</a> of an <a>index map</a> MUST be one
       of the following types:</p>
 
     <ul>
@@ -11656,7 +11656,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <h2>Property Nesting</h2>
 
     <p>A <a>nested property</a> is used to gather <a>properties</a> of a <a>node object</a> in a separate
-      <a>dictionary</a>, or <a>array</a> of <a>dictionaries</a> which are not
+      <a>map</a>, or <a>array</a> of <a>maps</a> which are not
       <a>value objects</a>. It is semantically transparent and is removed
       during the process of <a>expansion</a>. Property nesting is recursive, and
       collections of nested properties may contain further nesting.</p>
@@ -11671,7 +11671,7 @@ the data type to be specified explicitly with each piece of data.</p>
   <p>A <dfn>context definition</dfn> defines a <a>local context</a> in a
     <a>node object</a>.</p>
 
-  <p>A <a>context definition</a> MUST be a <a>dictionary</a> whose
+  <p>A <a>context definition</a> MUST be a <a>map</a> whose
     keys MUST be either <a>terms</a>, <a>compact IRIs</a>, <a>absolute IRIs</a>,
     or one of the <a>keywords</a> <code>@language</code>, <code>@base</code>,
     <code class="changed">@type</code>, <code>@vocab</code>, or <code class="changed">@version</code>.</p>
@@ -11684,7 +11684,7 @@ the data type to be specified explicitly with each piece of data.</p>
     or <a>null</a>.</p>
 
   <p class="changed">If the <a>context definition</a> has an <code>@type</code> key,
-    its value MUST be a <a>dictionary</a> with the single member <code>@container</code> set to <code>@set</code>.</p>
+    its value MUST be a <a>map</a> with the single <a>entry</a> <code>@container</code> set to <code>@set</code>.</p>
 
   <p>If the <a>context definition</a> has an <code>@vocab</code> key,
     its value MUST be a <a>absolute IRI</a>, a <a>compact IRI</a>,
@@ -11705,7 +11705,7 @@ the data type to be specified explicitly with each piece of data.</p>
     properties of the value associated with the <a>term</a> when it is
     used as key in a <a>node object</a>.</p>
 
-  <p>An <a>expanded term definition</a> MUST be a <a>dictionary</a>
+  <p>An <a>expanded term definition</a> MUST be a <a>map</a>
     composed of zero or more keys from
     <code>@id</code>,
     <code>@reverse</code>,
@@ -11729,11 +11729,11 @@ the data type to be specified explicitly with each piece of data.</p>
     a <a>blank node identifier</a>, a <a>compact IRI</a>, a <a>term</a>,
     or a <a>keyword</a>.</p>
 
-  <p>If an <a>expanded term definition</a> has an <code>@reverse</code> <a>member</a>,
-    it MUST NOT have <code>@id</code> or <code>@nest</code> <a>members</a> at the same time,
+  <p>If an <a>expanded term definition</a> has an <code>@reverse</code> <a>entry</a>,
+    it MUST NOT have <code>@id</code> or <code>@nest</code> <a>entries</a> at the same time,
     its value MUST be an <a>absolute IRI</a>,
     a <a>blank node identifier</a>, a <a>compact IRI</a>, or a <a>term</a>. If an
-    <code>@container</code> <a>member</a> exists, its value MUST be <a>null</a>,
+    <code>@container</code> <a>entry</a> exists, its value MUST be <a>null</a>,
     <code>@set</code>, or <code>@index</code>.</p>
 
   <p>If the <a>expanded term definition</a> contains the <code>@type</code>
@@ -11770,7 +11770,7 @@ the data type to be specified explicitly with each piece of data.</p>
     the <code>@context</code>, the associated value MUST be an
     <a>index map</a>.</p>
 
-  <p class="changed">If an <a>expanded term definition</a> has an <code>@context</code> <a>member</a>,
+  <p class="changed">If an <a>expanded term definition</a> has an <code>@context</code> <a>entry</a>,
     it MUST be a valid <code>context definition</code>.</p>
 
   <p class="changed">If the <a>expanded term definition</a> contains the <code>@nest</code>
@@ -11880,7 +11880,7 @@ the data type to be specified explicitly with each piece of data.</p>
       The <code>@nest</code> keyword MAY be aliased and MAY be used as a key in a <a>node object</a>.
       The unaliased <code>@nest</code> MAY be used as the value of a <a>simple term definition</a>,
       or as a key in an <a>expanded term definition</a>.
-      When used in a <a>node object</a>, its value must be a <a>dictionary</a>.
+      When used in a <a>node object</a>, its value must be a <a>map</a>.
       When used in an <a>expanded term definition</a>, its value MUST be a term expanding to <code>@nest</code>.
       Its value MUST be a <a>string</a>.
       See <a class="sectionRef" href="#property-nesting"></a> for a further discussion.
@@ -12148,8 +12148,8 @@ the data type to be specified explicitly with each piece of data.</p>
         Two JSON values <var>A</var> and <var>B</var> are considered equal if and only if the following is true:
         <ol>
           <li>If <var>A</var> and <var>B</var> are both <a>objects</a>,
-            both <var>A</var> and <var>B</var> have the same number of <a>members</a>,
-            and each <a>member</a> in <var>A</var> is equal to a corresponding <a>member</a> in <var>B</var>
+            both <var>A</var> and <var>B</var> have the same number of <a>entries</a>,
+            and each <a>entry</a> in <var>A</var> is equal to a corresponding <a>entry</a> in <var>B</var>
             where <ul>
               <li>the keys are equal (as defined in <a data-cite="ECMASCRIPT#sec-samevaluenonnumber">Section 7.2.12, step 5.a</a>
                   in [[ECMASCRIPT]]), and</li>
@@ -12797,7 +12797,7 @@ the data type to be specified explicitly with each piece of data.</p>
 <section class="appendix informative" id="changes-from-10">
   <h2>Changes since 1.0 Recommendation of 16 January 2014</h2>
   <ul>
-    <li>A context may contain a <code>@version</code> <a>member</a> which is used to set the <a>processing mode</a>.</li>
+    <li>A context may contain a <code>@version</code> <a>entry</a> which is used to set the <a>processing mode</a>.</li>
     <li>An <a>expanded term definition</a> can now have an
       <code>@context</code> property, which defines a <a>context</a> used for values of
       a <a>property</a> identified with such a <a>term</a>.</li>
@@ -12825,7 +12825,7 @@ the data type to be specified explicitly with each piece of data.</p>
       when compacting only if
       a <a>simple term definition</a> is used where the value ends with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
       or if their <a>expanded term definition</a> contains
-      a <code>@prefix</code> <a>member</a> with the value <code>true</code>. The 1.0 algorithm has
+      a <code>@prefix</code> <a>entry</a> with the value <code>true</code>. The 1.0 algorithm has
       been updated to only consider terms that map to a value that ends with a URI
       <a data-cite="RFC3986#section-2.2">gen-delim</a> character.</li>
     <li>Values of properties where the associated <a>term definition</a>
@@ -12845,8 +12845,8 @@ the data type to be specified explicitly with each piece of data.</p>
   <ul>
     <li><a>Lists</a> may now have items which are themselves <a>lists</a>.</li>
     <li>Values of <code>@type</code>, or an alais of <code>@type</code>, may now have their <code>@container</code> set to <code>@set</code>
-      to ensure that <code>@type</code> members are always represented as an array. This
-      also allows a term to be defined for <code>@type</code>, where the value MUST be a <a>dictionary</a>
+      to ensure that <code>@type</code> <a>entries</a> are always represented as an array. This
+      also allows a term to be defined for <code>@type</code>, where the value MUST be a <a>map</a>
       with <code>@container</code> set to <code>@set</code>.</li>
     <li>The use of <a>blank node identifiers</a> to label properties is obsolete,
       and may be removed in a future version of JSON-LD, as is the support for <a>generalized RDF Datasets</a>.</li>


### PR DESCRIPTION
This mirrors changes to the API document, but also attempts to clean up our shared terms to reference outside specs as much as possible.

Note that there is still some overlap between WebIDL definitions and ECMASCRIPT, particularly for _dictionary_ and _dictionary member_.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/198.html" title="Last updated on Jul 9, 2019, 8:37 PM UTC (0f6e413)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/198/3ed3de7...0f6e413.html" title="Last updated on Jul 9, 2019, 8:37 PM UTC (0f6e413)">Diff</a>