### PR TITLE
Add section for `@propagate` and stub for `@import`.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,10 @@
 source "https://rubygems.org"
 
 gem 'json-ld', github: 'ruby-rdf/json-ld', branch: 'develop'
+gem 'json-ld-preloaded'
 gem 'nokogiri'
 gem 'nokogumbo'
 gem 'linkeddata'
 gem 'colorize'
 gem 'rake'
+gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/ruby-rdf/json-ld.git
-  revision: 74a05a9f623c5a9e02cbe42f053f9d09181fee97
+  revision: 813e1ff914cc1a1025db14de392fd738b4cbb674
   branch: develop
   specs:
     json-ld (3.0.2)
@@ -18,6 +18,7 @@ GEM
     bcp47 (0.3.3)
       i18n
     builder (3.2.3)
+    byebug (11.0.1)
     colorize (0.8.1)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
@@ -26,7 +27,7 @@ GEM
       sxp (~> 1.0)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
-    haml (5.0.4)
+    haml (5.1.1)
       temple (>= 0.8.0)
       tilt
     hamster (3.0.0)
@@ -73,13 +74,13 @@ GEM
       sparql-client (~> 3.0)
     mini_portile2 (2.4.0)
     multi_json (1.13.1)
-    net-http-persistent (3.0.0)
+    net-http-persistent (3.0.1)
       connection_pool (~> 2.2)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     nokogumbo (1.5.0)
       nokogiri
-    public_suffix (3.0.3)
+    public_suffix (3.1.1)
     rack (2.0.7)
     rake (12.3.2)
     rdf (3.0.12)
@@ -113,17 +114,17 @@ GEM
       rdf (>= 2.2, < 4.0)
       rdf-rdfa (>= 2.2, < 4.0)
       rdf-xsd (>= 2.2, < 4.0)
-    rdf-reasoner (0.5.1)
+    rdf-reasoner (0.5.2)
       rdf (~> 3.0)
       rdf-vocab (~> 3.0)
       rdf-xsd (~> 3.0)
-    rdf-tabular (2.2.1)
+    rdf-tabular (2.2.2)
       addressable (~> 2.3)
       bcp47 (~> 0.3, >= 0.3.3)
       json-ld (>= 2.1, < 4.0)
-      rdf (>= 2.2, < 4.0)
-      rdf-vocab (>= 2.2, < 4.0)
-      rdf-xsd (>= 2.2, < 4.0)
+      rdf (~> 3.0)
+      rdf-vocab (~> 3.0)
+      rdf-xsd (~> 3.0)
     rdf-trig (3.0.1)
       ebnf (~> 1.1)
       rdf (~> 3.0)
@@ -133,7 +134,7 @@ GEM
     rdf-turtle (3.0.6)
       ebnf (~> 1.1)
       rdf (~> 3.0)
-    rdf-vocab (3.0.5)
+    rdf-vocab (3.0.7)
       rdf (~> 3.0, >= 3.0.11)
     rdf-xsd (3.0.1)
       rdf (~> 3.0)
@@ -165,8 +166,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  byebug
   colorize
   json-ld!
+  json-ld-preloaded
   linkeddata
   nokogiri
   nokogumbo

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: git://github.com/ruby-rdf/json-ld.git
-  revision: 813e1ff914cc1a1025db14de392fd738b4cbb674
+  remote: https://github.com/ruby-rdf/json-ld.git
+  revision: 74095b73cdb722b681f34d0f165599c9cb48d844
   branch: develop
   specs:
     json-ld (3.0.2)
@@ -176,4 +176,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.17.3
+   2.0.2

--- a/common/extract-examples.rb
+++ b/common/extract-examples.rb
@@ -10,6 +10,7 @@
 # - @data-options indicates the comma-separated option/value pairs to pass to the processor
 require 'getoptlong'
 require 'json'
+require 'json/ld/preloaded'
 require 'nokogiri'
 require 'linkeddata'
 require 'fileutils'

--- a/index.html
+++ b/index.html
@@ -3747,7 +3747,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
   </pre>
 
   <p>Again, the effect would be the same as if the entire sourced <a>context</a>
-    had been copied into the type-scoped <a>context</a>:</p>
+    had been copied into the <a>context</a>:</p>
 
   <pre class="example nohighlight" data-transform="updateExample"
        title="Result of sourcing a context to modify @vocab and a term definition">

--- a/index.html
+++ b/index.html
@@ -600,7 +600,7 @@
         (other than for type-<a>scoped contexts</a>, which default to `false`).
         Setting this to `false` causes term definitions created within that context
         to be removed when entering a new <a>node object</a>.</dd>
-      <dt class="changed">`@source`</dt><dd class="changed">
+      <dt class="changed">`@import`</dt><dd class="changed">
         Used in a <a>context definition</a> to load an external context
         within which the containing <a>context definition</a> is merged.
         This can be useful to add JSON-LD 1.1 features to JSON-LD 1.0 contexts.</dd>
@@ -3626,7 +3626,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     due to the way that rollback is defined in [[[JSON-LD11-API]]].</p>
 </section>
 
-<section class="informative changed"><h2>Sourced Contexts</h2>
+<section class="informative changed"><h2>Imported Contexts</h2>
   <p>JSON-LD 1.0 included mechanisms for modifying the <a>context</a> that
     is in effect. This included the capability to load and process a remote
     <a>context</a> and then apply further changes to it via new <a>contexts</a>.
@@ -3637,39 +3637,39 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     1.0 <a>context</a>, and apply JSON-LD 1.1 features to it prior to
     processing.</p>
 
-  <p>By using the `@source` keyword in a <a>context</a>, another remote
-    <a>context</a>, referred to as a sourced <a>context</a>, can be loaded and
+  <p>By using the `@import` keyword in a <a>context</a>, another remote
+    <a>context</a>, referred to as an imported <a>context</a>, can be loaded and
     modified prior to processing. The modifications are expressed in the
-    <a>context</a> that includes the `@source` keyword, referred to as the
-    wrapping <a>context</a>. Once a sourced <a>context</a> is loaded, the
+    <a>context</a> that includes the `@import` keyword, referred to as the
+    wrapping <a>context</a>. Once an imported <a>context</a> is loaded, the
     contents of the wrapping <a>context</a> are merged into it prior to
     processing. The merge operation will cause each key-value pair in the
-    wrapping <a>context</a> to be added to the loaded sourced <a>context</a>,
+    wrapping <a>context</a> to be added to the loaded imported <a>context</a>,
     with the wrapping <a>context</a> key-value pairs taking precedence.</p>
 
   <p>By enabling existing <a>contexts</a> to be reused and edited inline prior
     to processing, context-wide keywords can be applied to adjust all term
-    definitions in the sourced <a>context</a>. Similarly, term definitions can
+    definitions in the imported <a>context</a>. Similarly, term definitions can
     be replaced prior to processing, enabling adjustments that, for instance, ensure term
     definitions match previously protected terms or that they include
     additional type coercion information.</p>
 
-  <p>The following examples illustrate how `@source` can be used to express
-    a type-scoped <a>context</a> that loads a sourced <a>context</a> and
+  <p>The following examples illustrate how `@import` can be used to express
+    a type-scoped <a>context</a> that loads an imported <a>context</a> and
     sets `@propagate` to `true` and how to make similar modifications.</p>
 
   <p>Suppose there was a <a>context</a> that could be referenced remotely
-    via the URL <code>http://example.org/remote-context</code>:</p>
+    via the URL <code>https://json-ld.org/contexts/remote-context.jsonld</code>:</p>
 
   <pre class="example nohighlight" data-transform="updateExample"
-       title="A remote context to be sourced in a type-scoped context">
+       title="A remote context to be imported in a type-scoped context">
   <!--
   {
     "@context": {
       "Type1": "http://example.com/vocab/Type1",
       "Type2": "http://example.com/vocab/Type2",
       "term1": "http://example.com/vocab#term1",
-      "term2": "http://example.com/vocab#term2",####,
+      "term2": "http://example.com/vocab#term2"####,
       ...####
     }
   }
@@ -3688,7 +3688,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
         "@id": "http://example.com/vocab#MyType",
         "@context": {
           "@version": 1.1,
-          "@source": "https://example.com/remote-context",
+          "@import": "https://json-ld.org/contexts/remote-context.jsonld",
           "@propagate": true
         }
       }
@@ -3697,7 +3697,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
   -->
   </pre>
 
-  <p>The effect would be the same as if the entire sourced <a>context</a>
+  <p>The effect would be the same as if the entire imported <a>context</a>
     had been copied into the type-scoped <a>context</a>:</p>
 
   <pre class="example nohighlight" data-transform="updateExample"
@@ -3713,7 +3713,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
           "Type1": "http://example.com/vocab/Type1",
           "Type2": "http://example.com/vocab/Type2",
           "term1": "http://example.com/vocab#term1",
-          "term2": "http://example.com/vocab#term2",####,
+          "term2": "http://example.com/vocab#term2",####
           ...####
           "@propagate": true
         }
@@ -3724,7 +3724,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
   </pre>
 
   <p>Similarly, the wrapping <a>context</a> may replace term definitions or
-    set other context-wide keywords that may effect how the sourced
+    set other context-wide keywords that may effect how the imported
     <a>context</a> term definitions will be processed:</p>
 
   <pre class="example nohighlight" data-transform="updateExample"
@@ -3733,7 +3733,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
   {
     "@context": {
       "@version": 1.1,
-      "@source": "https://example.org/remote-context",
+      "@import": "https://json-ld.org/contexts/remote-context.jsonld",
       "@vocab": "http://example.org/vocab#",
       #### ↑ This will replace any previous @vocab definition prior to processing it####
       "term1": {
@@ -3746,7 +3746,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
   -->
   </pre>
 
-  <p>Again, the effect would be the same as if the entire sourced <a>context</a>
+  <p>Again, the effect would be the same as if the entire imported <a>context</a>
     had been copied into the <a>context</a>:</p>
 
   <pre class="example nohighlight" data-transform="updateExample"
@@ -3770,7 +3770,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
   -->
   </pre>
 
-  <p class="note">The result of loading a sourced <a>contexts</a> must be
+  <p class="warning">The result of loading imported <a>contexts</a> must be
     an object, not an array.</p>
 </section>
 
@@ -11964,14 +11964,14 @@ the data type to be specified explicitly with each piece of data.</p>
   <p>An <a>expanded term definition</a> MUST be a <a>map</a>
     composed of zero or more keys from
     <code>@id</code>,
+    <code class="changed">@import</code>,
     <code>@reverse</code>,
     <code>@type</code>,
     <code>@language</code>,
     <code>@container</code>,
     <code class="changed">@context</code>,
-    <code class="changed">@prefix</code>,
-    <code class="changed">@propagate</code>, or
-    <code class="changed">@source</code>.
+    <code class="changed">@prefix</code>, or
+    <code class="changed">@propagate</code>.
     An <a>expanded term definition</a> SHOULD NOT contain any other keys.</p>
 
   <p>If the term being defined is not a <a>compact IRI</a> or
@@ -12041,7 +12041,7 @@ the data type to be specified explicitly with each piece of data.</p>
   <p class="changed">If the <a>expanded term definition</a> contains the <code>@propagate</code>
     <a>keyword</a>, its value MUST be <code>true</code> or <code>false</code>.</p>
 
-  <p class="changed">If the <a>expanded term definition</a> contains the <code>@source</code>
+  <p class="changed">If the <a>expanded term definition</a> contains the <code>@import</code>
     <a>keyword</a>, its value MUST be an <a>absolute IRI</a> or <a>relative IRI</a>.</p>
 
   <p><a>Terms</a> MUST NOT be used in a circular manner. That is,
@@ -12202,10 +12202,10 @@ the data type to be specified explicitly with each piece of data.</p>
 
       <p>See <a class="sectionRef" href="#sets-and-lists"></a> for further discussion on sets and lists.</p>
     </dd>
-    <dt class="changed">`@source`</dt><dd class="changed">
-      The `@source` keyword MUST NOT be aliased, and MAY be used in a <a>context definition</a>.
+    <dt class="changed">`@import`</dt><dd class="changed">
+      The `@import` keyword MUST NOT be aliased, and MAY be used in a <a>context definition</a>.
       Its value MUST be an <a>absolute IRI</a> or <a>relative IRI</a>.
-      See <a class="sectionRef" href="#sourced-contexts"></a> for a further discussion.
+      See <a class="sectionRef" href="#imported-contexts"></a> for a further discussion.
     </dd>
     <dt><code>@type</code></dt><dd>
       The <code>@type</code> keyword MAY be aliased and MAY be used as a key in a <a>node object</a> or a <a>value object</a>.
@@ -13156,7 +13156,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <li>By default, all contexts are propagated when traversing <a>node objects</a>, other than
       type-scoped contexts. This can be controlled using the <code>@propagate</code>
       <a>entry</a> in a <a>local context</a>.</li>
-    <li>A context may contain a <code>@source</code> <a>entry</a> used to reference a remote context
+    <li>A context may contain an <code>@import</code> <a>entry</a> used to reference a remote context
       within a context, allowing <code>JSON-LD 1.1</code> features to be added to contexts originally
       authored for <code>JSON-LD 1.0</code>.</li>
   </ul>

--- a/index.html
+++ b/index.html
@@ -3627,7 +3627,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
 </section>
 
 <section class="informative changed"><h2>Sourced Contexts</h2>
-  <p>JSON-LD 1.0 included a mechanisms for modifying the <a>context</a> that
+  <p>JSON-LD 1.0 included mechanisms for modifying the <a>context</a> that
     is in effect. This included the capability to load and process a remote
     <a>context</a> and then apply further changes to it via new <a>contexts</a>.
   </p>

--- a/index.html
+++ b/index.html
@@ -3654,9 +3654,9 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     definitions match previously protected terms or that they include
     additional type coercion information.</p>
 
-  <p>The following example illustrates how `@source` can be used to express
+  <p>The following examples illustrate how `@source` can be used to express
     a type-scoped <a>context</a> that loads a sourced <a>context</a> and
-    sets `@propagate` to `true`.</p>
+    sets `@propagate` to `true` and how to make similar modifications.</p>
 
   <p>Suppose there was a <a>context</a> that could be referenced remotely
     via the URL <code>http://example.org/remote-context</code>:</p>

--- a/index.html
+++ b/index.html
@@ -3627,6 +3627,151 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
 </section>
 
 <section class="informative changed"><h2>Sourced Contexts</h2>
+  <p>JSON-LD 1.0 included a mechanisms for modifying the <a>context</a> that
+    is in effect. This included the capability to load and process a remote
+    <a>context</a> and then apply further changes to it via new <a>contexts</a>.
+  </p>
+
+  <p>However, with the introduction of JSON-LD 1.1, it is also desirable to
+    be able to load a remote <a>context</a>, in particular an existing JSON-LD
+    1.0 <a>context</a>, and apply JSON-LD 1.1 features to it prior to
+    processing.</p>
+
+  <p>By using the `@source` keyword in a <a>context</a>, another remote
+    <a>context</a>, referred to as a sourced <a>context</a>, can be loaded and
+    modified prior to processing. The modifications are expressed in the
+    <a>context</a> that includes the `@source` keyword, referred to as the
+    wrapping <a>context</a>. Once a sourced <a>context</a> is loaded, the
+    contents of the wrapping <a>context</a> are merged into it prior to
+    processing. The merge operation will cause each key-value pair in the
+    wrapping <a>context</a> to be added to the loaded sourced <a>context</a>,
+    key-value pairs taking precedence.</p>
+
+  <p>By enabling existing <a>contexts</a> to be reused and edited inline prior
+    to processing, context-wide keywords can be applied to adjust all term
+    definitions in the sourced <a>context</a>. Similarly, term definitions can
+    be replaced prior to processing, enabling adjustments that, for instance, ensure term
+    definitions match previously protected terms or that they include
+    additional type coercion information.</p>
+
+  <p>The following example illustrates how `@source` can be used to express
+    a type-scoped <a>context</a> that loads a sourced <a>context</a> and
+    sets `@propagate` to `true`.</p>
+
+  <p>Suppose there was a <a>context</a> that could be referenced remotely
+    via the URL <code>http://example.org/remote-context</code>:</p>
+
+  <pre class="example nohighlight" data-transform="updateExample"
+       title="A remote context to be sourced in a type-scoped context">
+  <!--
+  {
+    "@context": {
+      "Type1": "http://example.com/vocab/Type1",
+      "Type2": "http://example.com/vocab/Type2",
+      "term1": "http://example.com/vocab#term1",
+      "term2": "http://example.com/vocab#term2",####,
+      ...####
+    }
+  }
+  -->
+  </pre>
+
+  <p>A wrapping <a>context</a> could be used to source it and modify it:</p>
+
+  <pre class="example nohighlight" data-transform="updateExample"
+       title="Sourcing a context in a type-scoped context and setting it to propagate">
+  <!--
+  {
+    "@context": {
+      "@version": 1.1,
+      "MyType": {
+        "@id": "http://example.com/vocab#MyType",
+        "@context": {
+          "@version": 1.1,
+          "@source": "https://example.com/remote-context",
+          "@propagate": true
+        }
+      }
+    }
+  }
+  -->
+  </pre>
+
+  <p>The effect would be the same as if the entire sourced <a>context</a>
+    had been copied into the type-scoped <a>context</a>:</p>
+
+  <pre class="example nohighlight" data-transform="updateExample"
+       title="Result of sourcing a context in a type-scoped context and setting it to propagate">
+  <!--
+  {
+    "@context": {
+      "@version": 1.1,
+      "MyType": {
+        "@id": "http://example.com/vocab#MyType",
+        "@context": {
+          "@version": 1.1,
+          "Type1": "http://example.com/vocab/Type1",
+          "Type2": "http://example.com/vocab/Type2",
+          "term1": "http://example.com/vocab#term1",
+          "term2": "http://example.com/vocab#term2",####,
+          ...####
+          "@propagate": true
+        }
+      }
+    }
+  }
+  -->
+  </pre>
+
+  <p>Similarly, the wrapping <a>context</a> may replace term definitions or
+    set other context-wide keywords that may effect how the sourced
+    <a>context</a> term definitions will be processed:</p>
+
+  <pre class="example nohighlight" data-transform="updateExample"
+       title="Sourcing a context to modify @vocab and a term definition">
+  <!--
+  {
+    "@context": {
+      "@version": 1.1,
+      "@source": "https://example.org/remote-context",
+      "@vocab": "http://example.org/vocab#",
+      #### ↑ This will replace any previous @vocab definition prior to processing it at all####
+      "term1": {
+        "@id": "http://example.org/vocab#term1",
+        "@type": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+      #### ↑ This will replace the old term1 definition prior to processing it at all####
+    }
+  }
+  -->
+  </pre>
+
+  <p>Again, the effect would be the same as if the entire sourced <a>context</a>
+    had been copied into the type-scoped <a>context</a>:</p>
+
+  <pre class="example nohighlight" data-transform="updateExample"
+       title="Result of sourcing a context to modify @vocab and a term definition">
+  <!--
+  {
+    "@context": {
+      "@version": 1.1,
+      "Type1": "http://example.com/vocab/Type1",
+      "Type2": "http://example.com/vocab/Type2",
+      "term1": {
+        "@id": "http://example.org/vocab#term1",
+        "@type": "http://www.w3.org/2001/XMLSchema#integer"
+      }
+      #### ↑ Note term1 has been replaced prior to processing####
+      "term2": "http://example.com/vocab#term2",####,
+      ...####
+      "@vocab": "http://example.org/vocab#"
+    }
+  }
+  -->
+  </pre>
+
+  <p class="note">The result of loading a sourced <a>contexts</a> must be
+    an object, not an array.</p>
 </section>
 
 <section class="informative changed"><h2>Protected Term Definitions</h2>

--- a/index.html
+++ b/index.html
@@ -2969,7 +2969,6 @@
 </section>
 
 <section class="informative"><h2>Aliasing Keywords</h2>
-
   <p>Each of the JSON-LD <a>keywords</a>,
     except for <code>@context</code>, may be aliased to application-specific
     keywords. This feature allows legacy JSON content to be utilized

--- a/index.html
+++ b/index.html
@@ -591,9 +591,19 @@
         Used as the <code>@type</code> value of a <a>JSON literal</a>.
         This keyword is described in <a href="#json-literals" class="sectionRef"></a>.
       </dd>
-      <dt><code>:</code></dt>
-      <dd>The separator for JSON keys and values that use
-        <a>compact IRIs</a>.</dd>
+      <dt class="changed"><code>:</code></dt><dd class="changed">
+        The separator for JSON keys and values that use <a>compact IRIs</a>.</dd>
+      <dt class="changed">`@propagate`</dt><dd class="changed">
+        Used in a <a>context definition</a> to change the sccope of that context.
+        By default, it is `true`,
+        meaning that contexts propagate across <a>node objects</a>
+        (other than for type-<a>scoped contexts</a>, which default to `false`).
+        Setting this to `false` causes term definitions created within that context
+        to be removed when entering a new <a>node object</a>.</dd>
+      <dt class="changed">`@source`</dt><dd class="changed">
+        Used in a <a>context definition</a> to load an external context
+        within which the containing <a>context definition</a> is merged.
+        This can be useful to add JSON-LD 1.1 features to JSON-LD 1.0 contexts.</dd>
     </dl>
 
     <p>All keys, <a>keywords</a>, and values in JSON-LD are case-sensitive.</p>
@@ -3408,7 +3418,9 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     different things depending on the context.
     A <a>context</a> scoped on <code>@type</code> is only in effect for the <a>node object</a> on which
     the type is used; the previous in-scope <a>contexts</a> are placed back into
-    effect when traversing into another <a>node object</a>.</p>
+    effect when traversing into another <a>node object</a>.
+    As described further in <a href="#context-propagation" class="sectionRef"></a>,
+    this may be controlled using the `@propagate` keyword.</p>
 
   <p class="note">Any property-scoped or local contexts that were introduced in the <a>node object</a>
     would still be in effect when traversing into another <a>node object</a>.</p>
@@ -3518,6 +3530,103 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
 
   <p class="note"><a>Scoped Contexts</a> are a new feature in JSON-LD 1.1, requiring
     <a>processing mode</a> set to <code>json-ld-1.1</code>.</p>
+</section>
+
+<section class="informative changed"><h2>Context Propagation</h2>
+  <p>Once introduced, <a>contexts</a> remain in effect until a subsequent
+    <a>context</a> removes it by setting `@context` to `null`,
+    or by redefining terms,
+    with the exception of type-<a>scoped contexts</a>,
+    which limits the affect of that context until the next <a>node object</a> is entered.
+    This behavior can be changed using the `@propagate` keyword.</p>
+
+  <p>The following example illustrates how terms defined in a context with `@propagate` set to `false`
+    are effectively removed when descending into new <a>node object</a>.</p>
+
+  <aside class="example ds-selector-tabs"
+         title="Marking a context to not propagate">
+    <div class="selectors">
+      <button class="selected" data-selects="compacted">Compacted (Input)</button>
+      <button data-selects="expanded">Expanded (Result)</button>
+      <button data-selects="statements">Statements</button>
+      <button data-selects="turtle">Turtle</button>
+      <a class="playground" target="_blank"></a>
+    </div>
+    <pre class="compacted input selected nohighlight" data-transform="updateExample">
+    <!--
+    {
+      "@context": {
+        "@version": 1.1,
+        "term": {
+          "@id": "http://example.org/original",
+          "@context": {
+            "@propagate": false,
+            #### ↑ Scoped context only lasts in one node-object####
+            "term": "http://example.org/non-propagated-term"
+          }
+        }
+      },
+      "term": {
+      #### ↑ This term is the original####
+        "term": {
+        #### ↑ This term is from the scoped context####
+          "term": "This term is from the first context"
+          #### ↑ This term is the original again####
+        }
+      }
+    }
+    -->
+    </pre>
+    <pre class="expanded result result nohighlight"
+         data-transform="updateExample"
+         data-result-for="Marking a context to not propagate-compacted">
+    <!--
+    [{
+      "http://example.org/original": [{
+        "http://example.org/non-propagated-term": [{
+          "http://example.org/original": [
+            {"@value": "This term is from the first context"}
+          ]
+        }]
+      }]
+    }]
+    -->
+    </pre>
+    <table class="statements"
+           data-result-for="Marking a context to not propagate-expanded"
+           data-to-rdf
+           data-no-lint>
+      <thead><tr><th>Subject</th><th>Property</th><th>Value</th></tr></thead>
+      <tbody>
+        <tr><td>_:b2</td><td>http://example.org/original</td><td>This term is from the first context</td></tr>
+        <tr><td>_:b1</td><td>http://example.org/non-propagated-term</td><td>_:b2</td></tr>
+        <tr><td>_:b0</td><td>http://example.org/original</td><td>_:b1</td></tr>
+      </tbody>
+    </table>
+    <pre class="turtle"
+         data-content-type="text/turtle"
+         data-result-for="Marking a context to not propagate-expanded"
+         data-transform="updateExample"
+         data-to-rdf
+         data-no-lint>
+    <!--
+    @prefix ex: <http://example.org/> .
+    [
+      ex:original [
+        ex:non-propagated-term [
+          ex:original "This term is from the first context"
+        ]
+      ]
+    ] .
+    -->
+    </pre>
+  </aside>
+
+  <p class="note">Contexts included within an array must all have the same value for `@propagate`
+    due to the way that rollback is defined in [[[JSON-LD11-API]]].</p>
+</section>
+
+<section class="informative changed"><h2>Sourced Contexts</h2>
 </section>
 
 <section class="informative changed"><h2>Protected Term Definitions</h2>
@@ -11713,10 +11822,12 @@ the data type to be specified explicitly with each piece of data.</p>
     <code>@reverse</code>,
     <code>@type</code>,
     <code>@language</code>,
+    <code>@container</code>,
     <code class="changed">@context</code>,
-    <code class="changed">@prefix</code>, or
-    <code>@container</code>. An
-    <a>expanded term definition</a> SHOULD NOT contain any other keys.</p>
+    <code class="changed">@prefix</code>,
+    <code class="changed">@propagate</code>, or
+    <code class="changed">@source</code>.
+    An <a>expanded term definition</a> SHOULD NOT contain any other keys.</p>
 
   <p>If the term being defined is not a <a>compact IRI</a> or
     <a>absolute IRI</a> and the <a>active context</a> does not have an
@@ -11782,6 +11893,12 @@ the data type to be specified explicitly with each piece of data.</p>
   <p class="changed">If the <a>expanded term definition</a> contains the <code>@prefix</code>
     <a>keyword</a>, its value MUST be <code>true</code> or <code>false</code>.</p>
 
+  <p class="changed">If the <a>expanded term definition</a> contains the <code>@propagate</code>
+    <a>keyword</a>, its value MUST be <code>true</code> or <code>false</code>.</p>
+
+  <p class="changed">If the <a>expanded term definition</a> contains the <code>@source</code>
+    <a>keyword</a>, its value MUST be an <a>absolute IRI</a> or <a>relative IRI</a>.</p>
+
   <p><a>Terms</a> MUST NOT be used in a circular manner. That is,
     the definition of a term cannot depend on the definition of another term if that other
     term also depends on the first term.</p>
@@ -11789,7 +11906,7 @@ the data type to be specified explicitly with each piece of data.</p>
   <p>See <a class="sectionRef" href="#the-context"></a> for further discussion on contexts.</p>
 </section>
 
-<section class="normative changed">
+<section class="normative">
   <h2>Keywords</h2>
   <p>JSON-LD <a>keywords</a> are described in <a class="sectionRef" href="#syntax-tokens-and-keywords"></a>,
     this section describes where each <a>keyword</a> may appear within different JSON-LD structures.</p>
@@ -11806,17 +11923,17 @@ the data type to be specified explicitly with each piece of data.</p>
       <code>@set</code>,
       <code>@language</code>,
       <code>@index</code>,
-      <span><code>@id</code></span>,
-      <span><code>@graph</code></span>,
-      <span><code>@type</code></span>, or be
+      <code class="changed">@id</code>,
+      <code class="changed">@graph</code>,
+      <code class="changed">@type</code>, or be
       <a>null</a>,
-      or an <a>array</a> containing exactly any one of those keywords, or a
-      combination of <code>@set</code> and any of <code>@index</code>,
-      <code>@id</code>, <code>@graph</code>, <code>@type</code>,
-      <code>@language</code> in any order.
-      The value may also be an array
-      containing <code>@graph</code> along with either <code>@id</code> or
-      <code>@index</code> and also optionally including <code>@set</code>.
+      <span class="changed">or an <a>array</a> containing exactly any one of those keywords, or a
+        combination of <code>@set</code> and any of <code>@index</code>,
+        <code>@id</code>, <code>@graph</code>, <code>@type</code>,
+        <code>@language</code> in any order.
+        The value may also be an array
+        containing <code>@graph</code> along with either <code>@id</code> or
+        <code>@index</code> and also optionally including <code>@set</code></span>.
     </dd>
     <dt><code>@context</code></dt><dd>
       The <code>@context</code> keyword MUST NOT be aliased, and MAY be used as a key in the following objects:
@@ -11835,6 +11952,12 @@ the data type to be specified explicitly with each piece of data.</p>
       a <a>relative IRI</a>,
       a <a>context definition</a>, or
       an <a>array</a> composed of any of these.
+    </dd>
+    <dt>`@graph`</dt><dd>
+      The `@graph` keyword MAY be aliased and MAY be used as a key in a <a>node object</a> or a <a>graph object</a>.
+      The unaliased `@graph` MAY be used as the value of the <code>@container</code> key within an <a>expanded term definition</a>.
+      The value of the `@graph` key MUST be a <a>value object</a>, <a>node object</a>, or an array of either <a>value objects</a> or <a>node objects</a>.
+      See <a class="sectionRef" href="#named-graphs"></a>.
     </dd>
     <dt><code>@id</code></dt><dd>
       The <code>@id</code> keyword MAY be aliased and MAY be used as a key in a <a>node object</a> or a <a>graph object</a>.
@@ -11878,7 +12001,7 @@ the data type to be specified explicitly with each piece of data.</p>
 
       <p>See <a class="sectionRef" href="#sets-and-lists"></a> for further discussion on sets and lists.</p>
     </dd>
-    <dt><code>@nest</code></dt><dd>
+    <dt class="changed"><code>@nest</code></dt><dd class="changed">
       The <code>@nest</code> keyword MAY be aliased and MAY be used as a key in a <a>node object</a>.
       The unaliased <code>@nest</code> MAY be used as the value of a <a>simple term definition</a>,
       or as a key in an <a>expanded term definition</a>.
@@ -11887,7 +12010,7 @@ the data type to be specified explicitly with each piece of data.</p>
       Its value MUST be a <a>string</a>.
       See <a class="sectionRef" href="#property-nesting"></a> for a further discussion.
     </dd>
-    <dt><code>@none</code></dt><dd>
+    <dt class="changed"><code>@none</code></dt><dd class="changed">
       The <code>@none</code> keyword MAY be aliased and MAY be used as a key in an
       <a>index map</a>, <a>id map</a>, <a>language map</a>, <a>type map</a>.
       See <a class="sectionRef" href="#data-indexing"></a>,
@@ -11897,12 +12020,17 @@ the data type to be specified explicitly with each piece of data.</p>
       <a class="sectionRef" href="#named-graph-indexing"></a>, or
       <a class="sectionRef" href="#named-graph-data-indexing"></a>
       for a further discussion.</dd>
-    <dt><code>@prefix</code></dt><dd>
+    <dt class="changed"><code>@prefix</code></dt><dd class="changed">
       The <code>@prefix</code> keyword MUST NOT be aliased, and MAY be used as a key in an <a>expanded term definition</a>.
       Its value MUST be <code>true</code> or <code>false</code>.
       See <a class="sectionRef" href="#compact-iris"></a>
       and <a class="sectionRef" href="#context-definitions"></a>
       for a further discussion.
+    </dd>
+    <dt class="changed">`@propagate`</dt><dd class="changed">
+      The `@propagate` keyword MUST NOT be aliased, and MAY be used in a <a>context definition</a>.
+      Its value MUST be <code>true</code> or <code>false</code>.
+      See <a class="sectionRef" href="#context-propagation"></a> for a further discussion.
     </dd>
     <dt><code>@reverse</code></dt><dd>
       The <code>@reverse</code> keyword MAY be aliased and MAY be used as a key in a <a>node object</a>.
@@ -11929,6 +12057,11 @@ the data type to be specified explicitly with each piece of data.</p>
 
       <p>See <a class="sectionRef" href="#sets-and-lists"></a> for further discussion on sets and lists.</p>
     </dd>
+    <dt class="changed">`@source`</dt><dd class="changed">
+      The `@source` keyword MUST NOT be aliased, and MAY be used in a <a>context definition</a>.
+      Its value MUST be an <a>absolute IRI</a> or <a>relative IRI</a>.
+      See <a class="sectionRef" href="#sourced-contexts"></a> for a further discussion.
+    </dd>
     <dt><code>@type</code></dt><dd>
       The <code>@type</code> keyword MAY be aliased and MAY be used as a key in a <a>node object</a> or a <a>value object</a>.
       The unaliased <code>@type</code> MAY be used as a key in an <a>expanded term definition</a>,
@@ -11944,7 +12077,7 @@ the data type to be specified explicitly with each piece of data.</p>
       Its value key MUST be either a <a>string</a>, a <a>number</a>, <code>true</code>, <code>false</code> or <a>null</a>.
       This keyword is described further in <a class="sectionRef" href="#value-objects"></a>.
     </dd>
-    <dt><code>@version</code></dt><dd>
+    <dt class="changed"><code>@version</code></dt><dd class="changed">
       The <code>@version</code> keyword MUST NOT be aliased and MAY be used as a key in a <a>context definition</a>.
       Its value MUST be a <a>number</a> with the value <code>1.1</code>.
       This keyword is described further in <a class="sectionRef" href="#context-definitions"></a>.
@@ -12875,6 +13008,12 @@ the data type to be specified explicitly with each piece of data.</p>
       to limit the ability of other contexts to override them.</li>
     <li>A <a>context</a> defined in an <a>expanded term definition</a> may also be used for values
       of <code>@type</code>, which defines a <a>context</a> to use for <a>node objects</a> including the associated type.</li>
+    <li>By default, all contexts are propagated when traversing <a>node objects</a>, other than
+      type-scoped contexts. This can be controlled using the <code>@propagate</code>
+      <a>entry</a> in a <a>local context</a>.</li>
+    <li>A context may contain a <code>@source</code> <a>entry</a> used to reference a remote context
+      within a context, allowing <code>JSON-LD 1.1</code> features to be added to contexts originally
+      authored for <code>JSON-LD 1.0</code>.</li>
   </ul>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -3735,12 +3735,12 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
       "@version": 1.1,
       "@source": "https://example.org/remote-context",
       "@vocab": "http://example.org/vocab#",
-      #### ↑ This will replace any previous @vocab definition prior to processing it at all####
+      #### ↑ This will replace any previous @vocab definition prior to processing it####
       "term1": {
         "@id": "http://example.org/vocab#term1",
         "@type": "http://www.w3.org/2001/XMLSchema#integer"
       }
-      #### ↑ This will replace the old term1 definition prior to processing it at all####
+      #### ↑ This will replace the old term1 definition prior to processing it####
     }
   }
   -->
@@ -3760,10 +3760,10 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
       "term1": {
         "@id": "http://example.org/vocab#term1",
         "@type": "http://www.w3.org/2001/XMLSchema#integer"
-      }
+      },
       #### ↑ Note term1 has been replaced prior to processing####
-      "term2": "http://example.com/vocab#term2",####,
-      ...####
+      "term2": "http://example.com/vocab#term2",####
+      ...,####
       "@vocab": "http://example.org/vocab#"
     }
   }

--- a/index.html
+++ b/index.html
@@ -3645,7 +3645,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     contents of the wrapping <a>context</a> are merged into it prior to
     processing. The merge operation will cause each key-value pair in the
     wrapping <a>context</a> to be added to the loaded sourced <a>context</a>,
-    key-value pairs taking precedence.</p>
+    with the wrapping <a>context</a> key-value pairs taking precedence.</p>
 
   <p>By enabling existing <a>contexts</a> to be reused and edited inline prior
     to processing, context-wide keywords can be applied to adjust all term


### PR DESCRIPTION
Fixes #174.

(Still requires description of `@source`. Examples will fail until changes made to Ruby implementation, pending agreement on this and w3c/api#112.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/200.html" title="Last updated on Jul 12, 2019, 3:58 PM UTC (0384304)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/200/f5741e4...0384304.html" title="Last updated on Jul 12, 2019, 3:58 PM UTC (0384304)">Diff</a>