### PR TITLE
Terms update

### DIFF
--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -1,48 +1,48 @@
 <dl class="termlist" data-sort>
-  <dt><dfn>active graph</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-API#dfn-active-graph">active graph</dfn></dt><dd>
     The name of the currently active graph that the processor should use when processing.</dd>
-  <dt><dfn>active object</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-API#dfn-active-object">active object</dfn></dt><dd>
     The currently active object that the processor should use when processing.</dd>
-  <dt><dfn>active property</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-API#dfn-active-property">active property</dfn></dt><dd>
     The currently active <a>property</a> or <a>keyword</a> that the processor should use when processing.
     The <a>active property</a> is represented in the original lexical form,
     which is used for finding coercion mappings in the <a>active context</a>.</dd>
-  <dt><dfn>active subject</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-API#dfn-active-subject">active subject</dfn></dt><dd>
     The currently active subject that the processor should use when processing.</dd>
-  <dt><dfn>explicit inclusion flag</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-expicit-inclusion-flag">explicit inclusion flag</dfn></dt><dd>
     A flag specifying that for <a>properties</a> to be included in the output,
     they MUST be explicitly declared in the matching <a>frame</a>.</dd>
-  <dt><dfn>framing state</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-framing-state">framing state</dfn></dt><dd>
     A <a>map</a> containing values for the
     <a>object embed flag</a>, the
     <a>require all flag</a>, the
     <a>explicit inclusion flag</a>, and the
     <a>omit default flag</a>.</dd>
-  <dt><dfn>input frame</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-input-frame">input frame</dfn></dt><dd>
     The initial <a>Frame</a> provided to the framing algorithm.</dd>
-  <dt><dfn>JSON-LD input</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-API#dfn-json-ld-input">JSON-LD input</dfn></dt><dd>
     The JSON-LD data structure that is provided as input to the algorithm.</dd>
-  <dt><dfn>JSON-LD output</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-API#dfn-json-ld-output">JSON-LD output</dfn></dt><dd>
     The JSON-LD data structure that is produced as output by the algorithm.</dd>
-  <dt><dfn>map of flattened subjects</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-map-of-flattened-subjects">map of flattened subjects</dfn></dt><dd>
     A map of subjects that is the result of the
     <a data-cite="JSON-LD11-API#node-map-generation">Node Map Generation algorithm</a>.</dd>
-  <dt><dfn>object embed flag</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-object-embed-flag">object embed flag</dfn></dt><dd>
     A flag specifying that <a>node objects</a> should be directly embedded in the output,
     instead of being referred to by their <a>IRI</a>.</dd>
-  <dt><dfn>omit default flag</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-omit-default-flag">omit default flag</dfn></dt><dd>
     A flag specifying that properties that are missing from the <a>JSON-LD input</a>,
     but present in the <a>input frame</a>,
     should be omitted from the output.</dd>
-  <dt class="changed"><dfn>omit graph flag</dfn></dt><dd class="changed">
+  <dt class="changed"><dfn data-cite="JSON-LD11-FRAMING#dfn-omit-graph-flag">omit graph flag</dfn></dt><dd class="changed">
     A flag that determines if framing output is always contained within a <code>@graph</code> <a>entry</a>,
     or only if required to represent multiple <a>node objects</a>.</dd>
-  <dt><dfn>processor state</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-API#dfn-processor-state">processor state</dfn></dt><dd>
     The <a>processor state</a>,
     which includes the <a>active context</a>, <a>active subject</a>, and <a>active property</a>.
     The <a>processor state</a> is managed as a stack with elements from the previous <a>processor state</a>
     copied into a new <a>processor state</a> when entering a new <a>JSON object</a>.</dd>
-  <dt><dfn>require all flag</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-require-all-flag">require all flag</dfn></dt><dd>
     A flag specifying that all properties present in the <a>input frame</a>
     MUST either have a default value
     or be present in the <a>JSON-LD input</a>

--- a/common/terms.html
+++ b/common/terms.html
@@ -1,3 +1,4 @@
+<section><h3>Terms imported from [[[ECMASCRIPT]]] [[ECMASCRIPT]], [[[RFC8259]]] [[RFC8259]], [[[INFRA]]] [[INFRA]], and [[[WEBIDL]]] [[WEBIDL]]</h3>
 <dl class="termlist" data-sort>
   <dt><dfn data-cite="INFRA#list" class="preserve">array</dfn></dt><dd>
     In the JSON serialization,
@@ -11,6 +12,9 @@
     it is not in regular JSON-LD arrays unless specifically defined
     (see <a data-cite="JSON-LD11#sets-and-lists">Sets and Lists</a>
     in the JSON-LD Syntax specification [[JSON-LD11]]).</dd>
+  <dt><dfn data-cite="INFRA#boolean" class="preserve">boolean</dfn></dt><dd>
+    The values <code>true</code> and <code>false</code> that are used
+    to express one of two possible states.</dd>
   <dt><dfn data-cite="RFC8259#section-4" class="preserve">JSON object</dfn></dt><dd>
     In the JSON serialization,
     an <a>object</a> structure
@@ -25,11 +29,6 @@
       composed of <dfn data-cite="INFRA#map-entry" data-lt="map entry|entry" data-ld-noDefault class="preserve">entries</dfn> with key/value pairs.</p>
     <p>In the <a data-cite="JSON-LD11-API#the-application-programming-interface">Application Programming Interface</a>,
       a <a>map</a> is described using a [[WEBIDL]] <a data-cite="WEBIDL#dfn-dictionary">dictionary</a>.</p></dd>
-  <dt class="changed"><dfn data-cite="JSON-LD11-API#dfn-internal-representation" data-lt="internal representation">JSON-LD internal representation</dfn></dt><dd class="changed">
-    The JSON-LD internal representation
-    is the result of transforming a JSON syntactic structure
-    into the core data structures suitable for direct processing:
-    <a>arrays</a>, <a>maps</a>, <a>strings</a>, <a>numbers</a>, <a>booleans</a>, and <a>null</a>.</dd>
   <dt><dfn data-cite="INFRA#nulls" class="preserve">null</dfn></dt><dd>
     The use of the <a>null</a> value within JSON-LD
     is used to ignore or reset values.
@@ -56,21 +55,31 @@
     is a sequence of zero or more Unicode (UTF-8) characters,
     wrapped in double quotes, using backslash escapes (if necessary).
     A character is represented as a single character string.</dd>
-  <dt><dfn data-cite="INFRA#boolean" class="preserve">boolean</dfn></dt><dd>
-    The values <code>true</code> and <code>false</code> that are used
-    to express one of two possible states.</dd>
 </dl>
+</section>
 
-<p>Furthermore, the following terminology is used throughout this document:</p>
-
+<section><h3>Terms imported from [[[RFC3987]]] [[RFC3987]]</h3>
 <dl class="termlist" data-sort>
   <dt><dfn data-cite="RFC3987#section-1.3" class="preserve">absolute IRI</dfn></dt><dd>
     An <a>absolute IRI</a>
     is defined in [[RFC3987]] containing a <em>scheme</em> along with a <em>path</em>
     and optional <em>query</em> and fragment segments.</dd>
-  <dt><dfn data-cite="JSON-LD11#dfn-active-context">active context</dfn></dt><dd>
-    A <a>context</a> that is used to resolve <a>terms</a>
-    while the processing algorithm is running.</dd>
+  <dt><dfn data-cite="RFC3987#section-1.3" data-lt="IRI|Internationalized Resource Identifier" class="preserve"><abbr title="Internationalized Resource Identifier">IRI</abbr></dfn></dt><dd>
+    An <a>Internationalized Resource Identifier</a>
+    as described in [[RFC3987]].</dd>
+  <dt><dfn data-cite="RFC3987#section-6.5" class="preserve">relative IRI</dfn></dt><dd>
+    A relative IRI is an <a>IRI</a> that is relative to some other <a>absolute IRI</a>,
+    typically the <a>base IRI</a> of the document.
+    Note that <a>properties</a>,
+    values of <code>@type</code>,
+    and values of <a>terms</a> defined to be <em>vocabulary relative</em>
+    are resolved relative to the <a>vocabulary mapping</a>,
+    not the <a>base IRI</a>.</dd>
+</dl>
+</section>
+
+<section><h3>Terms imported from [[[RDF11-CONCEPTS]]] [[RDF11-CONCEPTS]], [[[RDF-SCHEMA]]] [[RDF-SCHEMA]], and [[[LINKED-DATA]]] [[LINKED-DATA]]</h3>
+<dl class="termlist" data-sort>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-base-iri" class="preserve">base IRI</dfn></dt><dd>
     The <a>base IRI</a> is an <a>absolute IRI</a> established in the <a>context</a>,
     or is based on the <a>JSON-LD document</a> location.
@@ -86,6 +95,71 @@
     A <a>blank node identifier</a>
     is a string that can be used as an identifier for a <a>blank node</a> within the scope of a JSON-LD document.
     Blank node identifiers begin with <code>_:</code>.</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-datatype-iri" class="preserve">datatype IRI</dfn></dt><dd>
+    A <a>datatype IRI</a> as specified by [[RDF11-CONCEPTS]].</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-default-graph" class="preserve">default graph</dfn></dt><dd>
+    The <a>default graph</a> is the only graph in a JSON-LD document which has no <a>graph name</a>.
+    When executing an algorithm,
+    the graph where data should be placed if a <a>named graph</a> is not specified.</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-graph-name" class="preserve">graph name</dfn></dt><dd>
+    The <a>IRI</a> or <a>blank node</a> identifying a <a>named graph</a>.</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-language-tagged-string" class="preserve">language-tagged string</dfn></dt><dd>
+    A <a>language-tagged string</a>
+    consists of a string and a non-empty language tag
+    as defined by [[BCP47]].
+    The <dfn data-cite="RDF11-CONCEPTS#dfn-language-tag">language tag</dfn> MUST be well-formed
+    according to <a data-cite="BCP47#section-2.2.9">section 2.2.9 Classes of Conformance</a> of [[BCP47]],
+    and is normalized to lowercase.</dd>
+  <dt><dfn data-cite="LINKED-DATA" data-no-xref="" class="preserve">Linked Data</dfn></dt><dd>
+    A set of documents, each containing a representation of a <a>linked data graph</a>.</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-graph" data-lt="linked data graph|graph" class="preserve">RDF graph</dfn></dt><dd>
+    A labeled directed <a>graph</a>,
+    i.e., a set of <a>nodes</a> connected by directed-arcs.</dd>
+  <dt><dfn data-cite="RDF-SCHEMA#ch_collectionvocab" data-lt="collection|RDF collection" class="preserve">list</dfn></dt><dd>
+    A <a>list</a> is an ordered sequence of <a>IRIs</a>, <a>blank nodes</a>, and <a>JSON-LD values</a>.</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-literal" data-lt="RDF literal" class="preserve">literal</dfn></dt><dd>
+    An <a>object</a> expressed as a value such as a string or number, or in expanded form as a <a>value object</a>.</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-named-graph" class="preserve">named graph</dfn></dt><dd>
+    A <a>named graph</a>
+    is a <a>linked data graph</a> that is identified by an <a>IRI</a> or <a>blank node</a>.</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-node" class="preserve">node</dfn></dt><dd>
+    Every <a>node</a> is an <a>IRI</a>,
+    a <a>blank node</a>,
+    a <a>JSON-LD value</a>,
+    or a <a>list</a>.
+    A piece of information that is represented in a <a>linked data graph</a>.</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-object" class="preserve">object</dfn></dt><dd>
+    An <a>object</a> is a <a>node</a> in a <a>linked data graph</a>
+    with at least one incoming edge.</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-property" class="preserve">property</dfn></dt><dd>
+    The name of a directed-arc in a <a>linked data graph</a>.
+    Every <a>property</a> is directional
+    and is labeled with an <a>IRI</a> or a <a>blank node identifier</a>.
+    Whenever possible, a <a>property</a> should be labeled with an <a>IRI</a>.
+    <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
+      and may be removed in a future version of JSON-LD.</div>
+    See <dfn data-cite="RDF11-CONCEPTS#dfn-predicate" class="preserve">predicate</dfn> in [[RDF11-CONCEPTS]].</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-dataset" data-lt="RDF dataset" class="preserve">dataset</dfn></dt><dd>
+    A <a>dataset</a>
+    as specified by [[RDF11-CONCEPTS]]
+    representing a collection of <a data-cite="RDF11-CONCEPTS#dfn-rdf-graph">RDF graphs</a>.</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-resource" class="preserve">resource</dfn></dt><dd>
+    A <a >resource</a> as specified by [[RDF11-CONCEPTS]].</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-triple" class="preserve">triple</dfn></dt><dd>
+    A <a>triple</a> as specified by [[RDF11-CONCEPTS]].</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-subject" class="preserve">subject</dfn></dt><dd>
+    A <a>subject</a> is a <a>node</a> in a <a>linked data graph</a>
+    with at least one outgoing edge,
+    related to an <a>object</a> node through a <a>property</a>.
+    See <dfn data-cite="RDF11-CONCEPTS#dfn-subject" class="preserve">RDF subject</dfn> in [[RDF11-CONCEPTS]].</dd>
+</dl>
+</section>
+
+<section><h3>JSON-LD Specific Term Definitions</h3>
+<dl class="termlist" data-sort>
+  <dt><dfn data-cite="JSON-LD11#dfn-active-context">active context</dfn></dt><dd>
+    A <a>context</a> that is used to resolve <a>terms</a>
+    while the processing algorithm is running.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-compact-iri">compact IRI</dfn></dt><dd>
     A compact IRI has the form of <a>prefix</a>:<em>suffix</em>
     and is used as a way of expressing an <a>IRI</a> without needing to define separate <a>term</a> definitions
@@ -93,12 +167,6 @@
   <dt><dfn data-cite="JSON-LD11#dfn-context">context</dfn></dt><dd>
     A set of rules for interpreting a <a>JSON-LD document</a>
     as specified in the <a data-cite="JSON-LD11#the-context">The Context</a> section of the JSON-LD Syntax specification [[JSON-LD11]].</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-datatype-iri" class="preserve">datatype IRI</dfn></dt><dd>
-    A <a>datatype IRI</a> as specified by [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-default-graph" class="preserve">default graph</dfn></dt><dd>
-    The <a>default graph</a> is the only graph in a JSON-LD document which has no <a>graph name</a>.
-    When executing an algorithm,
-    the graph where data should be placed if a <a>named graph</a> is not specified.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-default-language">default language</dfn></dt><dd>
     The default language is set in the <a>context</a> using the <code>@language</code> key
     whose value MUST be a <a>string</a> representing a [[BCP47]] language code or <code>null</code>.</dd>
@@ -131,23 +199,11 @@
     using matching and embedding rules.
     A frame document allows additional keywords and certain <a>map entries</a>
     to describe the matching and transforming process.</dd>
-  <dt><dfn data-cite="JSON-LD11-API#dfn-json-ld-processor" data-lt="json-ld processor|Processors">JSON-LD Processor</dfn></dt><dd>
-    A <a>JSON-LD Processor</a> is a system which can perform the algorithms defined in [[JSON-LD11-API]].</dd>
   <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-frame-object">frame object</dfn></dt><dd>
     A frame object is a <a>map</a> element within a <a>frame</a>
     which represents a specific portion of the <a>frame</a> matching either
     a <a>node object</a> or a <a>value object</a>
     in the input.</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-graph-name" class="preserve">graph name</dfn></dt><dd>
-    The <a>IRI</a> or <a>blank node</a> identifying a <a>named graph</a>.</dd>
-  <dt class="changed"><dfn data-cite="JSON-LD11#dfn-id-map">id map</dfn></dt><dd class="changed">
-    An <a>id map</a> is a <a>map</a> value of a <a>term</a>
-    defined with <code>@container</code> set to <code>@id</code>.
-    The values of the <a>id map</a> MUST be <a>node objects</a>,
-    and its keys are interpreted as <a>IRIs</a> representing
-    the <code>@id</code> of the associated <a>node object</a>.
-    If a value in the <a>id map</a> contains a key expanding to <code>@id</code>,
-    it's value MUST be equivalent to the referencing key in the <a>id map</a>.</dd>
   <dt class="changed"><dfn data-cite="JSON-LD11#dfn-graph-object">graph object</dfn></dt><dd class="changed">
     A <a>graph object</a> represents a <a>named graph</a>
     as the value of a <a>map entry</a> within a <a>node object</a>.
@@ -159,6 +215,18 @@
     but are not considered <a>graph objects</a> if they include any other <a>entries</a>.
     A top-level object consisting of <code>@graph</code> is also not a <a>graph object</a>.
     Note that a <a>node object</a> may also represent a <a>named graph</a> it it includes other properties.</dd>
+  <dt class="changed"><dfn data-cite="JSON-LD11#dfn-id-map">id map</dfn></dt><dd class="changed">
+    An <a>id map</a> is a <a>map</a> value of a <a>term</a>
+    defined with <code>@container</code> set to <code>@id</code>.
+    The values of the <a>id map</a> MUST be <a>node objects</a>,
+    and its keys are interpreted as <a>IRIs</a> representing
+    the <code>@id</code> of the associated <a>node object</a>.
+    If a value in the <a>id map</a> contains a key expanding to <code>@id</code>,
+    it's value MUST be equivalent to the referencing key in the <a>id map</a>.</dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-implicitly-named-graph">implicitly named graph</dfn></dt><dd>
+    A <a>named graph</a> created from the value of a <a>map entry</a>
+    having an <a>expanded term definition</a>
+    where <code>@container</code> is set to  <code>@graph</code>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-index-map">index map</dfn></dt><dd>
     An <a>index map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@index</code>,
@@ -174,13 +242,23 @@
     <a>set object</a>, or
     an <a>array</a> of zero or more of the above possibilities.
   </dd>
-  <dt><dfn data-cite="RFC3987#section-1.3" data-lt="IRI|Internationalized Resource Identifier" class="preserve"><abbr title="Internationalized Resource Identifier">IRI</abbr></dfn></dt><dd>
-    An <a>Internationalized Resource Identifier</a>
-    as described in [[RFC3987]].</dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-json-literal">JSON literal</dfn></dt><dd>
+    A <a>JSON literal</a> is a <a>literal</a> where the associated <a>IRI</a> is <code>rdf:JSON</code>.
+    In the <a>value object</a> representation, the value of <code>@type</code> is <code>@json</code>.
+    JSON literals represent values which are valid JSON [[RFC8259]].
+    See <dfn data-cite="JSON-LD11#dfn-json-datatype" data-cite="JSON-LD11#dfn-json-datatype" class="preserve">JSON datatype</dfn> in [[JSON-LD11]].
+  </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-json-ld-document">JSON-LD document</dfn></dt><dd>
     A <a>JSON-LD document</a> is a serialization of
     a collection of <a>graphs</a>
     and comprises exactly one <a>default graph</a> and zero or more <a>named graphs</a>.</dd>
+  <dt><dfn data-cite="JSON-LD11-API#dfn-json-ld-processor" data-lt="json-ld processor|Processors">JSON-LD Processor</dfn></dt><dd>
+    A <a>JSON-LD Processor</a> is a system which can perform the algorithms defined in [[JSON-LD11-API]].</dd>
+  <dt class="changed"><dfn data-cite="JSON-LD11-API#dfn-internal-representation" data-lt="internal representation">JSON-LD internal representation</dfn></dt><dd class="changed">
+    The JSON-LD internal representation
+    is the result of transforming a JSON syntactic structure
+    into the core data structures suitable for direct processing:
+    <a>arrays</a>, <a>maps</a>, <a>strings</a>, <a>numbers</a>, <a>booleans</a>, and <a>null</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-json-ld-value" class="preserve">JSON-LD value</dfn></dt><dd>
     A <a>JSON-LD value</a> is a <a>string</a>,
     a <a>number</a>,
@@ -201,46 +279,17 @@
     <a>string</a>, or
     an <a>array</a> of zero or more of the above possibilities.
   </dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-language-tagged-string" class="preserve">language-tagged string</dfn></dt><dd>
-    A <a>language-tagged string</a>
-    consists of a string and a non-empty language tag
-    as defined by [[BCP47]].
-    The <dfn data-cite="RDF11-CONCEPTS#dfn-language-tag">language tag</dfn> MUST be well-formed
-    according to <a data-cite="BCP47#section-2.2.9">section 2.2.9 Classes of Conformance</a> of [[BCP47]],
-    and is normalized to lowercase.</dd>
-  <dt><dfn data-cite="LINKED-DATA" data-no-xref="" class="preserve">Linked Data</dfn></dt><dd>
-    A set of documents, each containing a representation of a <a>linked data graph</a>.</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-graph" data-lt="graph|RDF graph" class="preserve">linked data graph</dfn></dt><dd>
-    A labeled directed <a>graph</a>,
-    i.e., a set of <a>nodes</a> connected by directed-arcs.</dd>
-  <dt><dfn data-cite="RDF-SCHEMA#ch_collectionvocab" data-lt="collection|RDF collection" class="preserve">list</dfn></dt><dd>
-    A <a>list</a> is an ordered sequence of <a>IRIs</a>, <a>blank nodes</a>, and <a>JSON-LD values</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-list-object">list object</dfn></dt><dd>
     A <a>list object</a> is a <a>map</a> that has a <code>@list</code> key.
     It may also have an <code>@index</code> key, but no other <a>entries</a>.</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-literal" data-lt="RDF literal" class="preserve">literal</dfn></dt><dd>
-    An <a>object</a> expressed as a value such as a string or number, or in expanded form as a <a>value object</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-local-context">local context</dfn></dt><dd>
     A <a>context</a> that is specified with a <a>map</a>,
     specified via the <code>@context</code> <a>keyword</a>.</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-named-graph" class="preserve">named graph</dfn></dt><dd>
-    A <a>named graph</a>
-    is a <a>linked data graph</a> that is identified by an <a>IRI</a> or <a>blank node</a>.</dd>
-  <dt><dfn data-cite="JSON-LD11#dfn-implicitly-named-graph">implicitly named graph</dfn></dt><dd>
-    A <a>named graph</a> created from the value of a <a>map entry</a>
-    having an <a>expanded term definition</a>
-    where <code>@container</code> is set to  <code>@graph</code>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-nested-property">nested property</dfn></dt><dd>
     A <a>nested property</a> is a key in a <a>node object</a>
     whose value is a <a>map</a> containing <a>entries</a> which are treated as if they were values of the <a>node object</a>.
     The <a>nested property</a> itself is semantically meaningless and used only to create a sub-structure within a <a>node object</a>.
   </dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-node" class="preserve">node</dfn></dt><dd>
-    Every <a>node</a> is an <a>IRI</a>,
-    a <a>blank node</a>,
-    a <a>JSON-LD value</a>,
-    or a <a>list</a>.
-    A piece of information that is represented in a <a>linked data graph</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-node-object">node object</dfn></dt><dd>
     A <a>node object</a> represents zero or more <a>properties</a> of a <a>node</a> in the <a>graph</a>
     serialized by the <a>JSON-LD document</a>.
@@ -255,10 +304,6 @@
   </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-node-reference">node reference</dfn></dt><dd>
     A <a>node object</a> used to reference a node having only the <code>@id</code> key.</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-object" class="preserve">object</dfn></dt><dd>
-    An <a>object</a> is a <a>node</a> in a <a>linked data graph</a>
-    with at least one incoming edge.
-    See <dfn data-cite="RDF11-CONCEPTS#dfn-object" class="preserve">RDF object</dfn> in [[RDF11-CONCEPTS]].</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-prefix">prefix</dfn></dt><dd>
     A <a>prefix</a> is the first component of a <a>compact IRI</a>
     which comes from a <a>term</a> that maps to a string that,
@@ -271,38 +316,9 @@
     or via explicit API option,
     other processing modes can be accessed.
     This specification defines extensions for the <code>json-ld-1.1</code> <a>processing mode</a>.</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-property" class="preserve">property</dfn></dt><dd>
-    The name of a directed-arc in a <a>linked data graph</a>.
-    Every <a>property</a> is directional
-    and is labeled with an <a>IRI</a> or a <a>blank node identifier</a>.
-    Whenever possible, a <a>property</a> should be labeled with an <a>IRI</a>.
-    <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
-      and may be removed in a future version of JSON-LD.</div>
-    See <dfn data-cite="RDF11-CONCEPTS#dfn-predicate" data-lt="predicate" class="preserve">RDF predicate</dfn> in [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-dataset" data-lt="dataset" class="preserve">RDF dataset</dfn></dt><dd>
-    A <a>dataset</a>
-    as specified by [[RDF11-CONCEPTS]]
-    representing a collection of <a data-cite="RDF11-CONCEPTS#dfn-rdf-graph">RDF graphs</a>.</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-resource" data-lt="resource" class="preserve">RDF resource</dfn></dt><dd>
-    A <a >resource</a> as specified by [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-triple" data-lt="triple" class="preserve">RDF triple</dfn></dt><dd>
-    A <a>triple</a> as specified by [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn data-cite="RFC3987#section-6.5" class="preserve">relative IRI</dfn></dt><dd>
-    A relative IRI is an <a>IRI</a> that is relative to some other <a>absolute IRI</a>,
-    typically the <a>base IRI</a> of the document.
-    Note that <a>properties</a>,
-    values of <code>@type</code>,
-    and values of <a>terms</a> defined to be <em>vocabulary relative</em>
-    are resolved relative to the <a>vocabulary mapping</a>,
-    not the <a>base IRI</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-set-object">set object</dfn></dt><dd>
     A <a>set object</a> is a <a>map</a> that has an <code>@set</code> <a>entry</a>.
     It may also have an <code>@index</code> key, but no other <a>entries</a>.</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-subject" class="preserve">subject</dfn></dt><dd>
-    A <a>subject</a> is a <a>node</a> in a <a>linked data graph</a>
-    with at least one outgoing edge,
-    related to an <a>object</a> node through a <a>property</a>.
-    See <dfn data-cite="RDF11-CONCEPTS#dfn-subject" class="preserve">RDF subject</dfn> in [[RDF11-CONCEPTS]].</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-term">term</dfn></dt><dd>
     A <a>term</a> is a short word defined in a <a>context</a>
     that MAY be expanded to an <a>IRI</a>.
@@ -324,12 +340,6 @@
     the value MUST be a <a>node object</a>, or <a>array</a> of node objects.
     If the value contains a <a>term</a> expanding to <code>@type</code>,
     it's values are merged with the map value when expanding.</dd>
-  <dt><dfn data-cite="JSON-LD11#dfn-json-literal">JSON literal</dfn></dt><dd>
-    A <a>JSON literal</a> is a <a>literal</a> where the associated <a>IRI</a> is <code>rdf:JSON</code>.
-    In the <a>value object</a> representation, the value of <code>@type</code> is <code>@json</code>.
-    JSON literals represent values which are valid JSON [[RFC8259]].
-    See <dfn data-cite="JSON-LD11#dfn-json-datatype" data-cite="JSON-LD11#dfn-json-datatype" class="preserve">JSON datatype</dfn> in [[JSON-LD11]].
-  </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-typed-value" class="preserve">typed value</dfn></dt><dd>
     A <a>typed value</a> consists of a value,
     which is a <a>string</a>,
@@ -341,3 +351,4 @@
     The vocabulary mapping is set in the <a>context</a> using the <code>@vocab</code> key
     whose value MUST be an <a>IRI</a> or <code>null</code>.</dd>
 </dl>
+</section>

--- a/common/terms.html
+++ b/common/terms.html
@@ -61,12 +61,15 @@
 <p>Terms imported from [[[RFC3987]]] [[RFC3987]]</p>
 <dl class="termlist" data-sort>
   <dt><dfn data-cite="RFC3987#section-1.3" class="preserve">absolute IRI</dfn></dt><dd>
-    An <a>absolute IRI</a>
-    is defined in [[RFC3987]] containing a <em>scheme</em> along with a <em>path</em>
-    and optional <em>query</em> and fragment segments.</dd>
-  <dt><dfn data-cite="RFC3987#section-1.3" data-lt="IRI|Internationalized Resource Identifier" class="preserve"><abbr title="Internationalized Resource Identifier">IRI</abbr></dfn></dt><dd>
-    An <a>Internationalized Resource Identifier</a>
-    as described in [[RFC3987]].</dd>
+    The absolute form of an <a>IRI</a> containing a <em>scheme</em> along with a <em>path</em>
+    and optional <em>query</em> and <em>fragment</em> segments.</dd>
+  <dt><dfn data-cite="RFC3987#section-1.3" data-lt="IRI|Internationalized Resource Identifier" class="preserve"><abbr title="Internationalized Resource Identifier">IRI reference</abbr></dfn></dt><dd>
+    Denotes the common usage of an <a>Internationalized Resource Identifier</a>.
+    An <a>IRI reference</a> may be <a data-lt="absolute IRI">absolute</a> or
+    <a data-lt="relative IRI">relative</a>.
+    However, the "IRI" that results from such a reference
+    only includes <a>absolute IRIs</a>; any <a>relative IRI</a> references are
+    resolved to their absolute form.</dd>
   <dt><dfn data-cite="RFC3987#section-6.5" class="preserve">relative IRI</dfn></dt><dd>
     A relative IRI is an <a>IRI</a> that is relative to some other <a>absolute IRI</a>,
     typically the <a>base IRI</a> of the document.
@@ -94,12 +97,15 @@
     A <a>blank node identifier</a>
     is a string that can be used as an identifier for a <a>blank node</a> within the scope of a JSON-LD document.
     Blank node identifiers begin with <code>_:</code>.</dd>
+  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-dataset" data-lt="RDF dataset" class="preserve">dataset</dfn></dt><dd>
+    A <a>dataset</a>
+    representing a collection of <a data-cite="RDF11-CONCEPTS#dfn-rdf-graph">RDF graphs</a>
+    including exactly one <a>default graph</a> and zero or more <a>named graphs</a>.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-datatype-iri" class="preserve">datatype IRI</dfn></dt><dd>
-    A <a>datatype IRI</a> as specified by [[RDF11-CONCEPTS]].</dd>
+    A <a>datatype IRI</a> is an <a>IRI</a> identifying a datatype that determines how the lexical form maps to a
+    <a data-cite="RDF11-CONCEPTS#dfn-literal-value">literal value</a>.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-default-graph" class="preserve">default graph</dfn></dt><dd>
-    The <a>default graph</a> is the only graph in a JSON-LD document which has no <a>graph name</a>.
-    When executing an algorithm,
-    the graph where data should be placed if a <a>named graph</a> is not specified.</dd>
+    The <a>default graph</a> is an <a>RDF graph</a> having no <a data-lt="graph name">name</a>, which MAY be empty.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-graph-name" class="preserve">graph name</dfn></dt><dd>
     The <a>IRI</a> or <a>blank node</a> identifying a <a>named graph</a>.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-language-tagged-string" class="preserve">language-tagged string</dfn></dt><dd>
@@ -115,18 +121,15 @@
     A labeled directed <a>graph</a>,
     i.e., a set of <a>nodes</a> connected by directed-arcs.</dd>
   <dt><dfn data-cite="RDF-SCHEMA#ch_collectionvocab" data-lt="collection|RDF collection" class="preserve">list</dfn></dt><dd>
-    A <a>list</a> is an ordered sequence of <a>IRIs</a>, <a>blank nodes</a>, and <a>JSON-LD values</a>.</dd>
+    A <a>list</a> is an ordered sequence of <a>IRIs</a>, <a>blank nodes</a>, and <a>literals</a>.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-literal" data-lt="RDF literal" class="preserve">literal</dfn></dt><dd>
-    An <a>object</a> expressed as a value such as a string or number, or in expanded form as a <a>value object</a>.</dd>
+    An <a>object</a> expressed as a value such as a <a>string</a> or <a>number</a>.
+    Implicitlly or explicitly includes a <a>datatype IRI</a> and, if the datatype is `xsd:string`, an optional <a>language tag</a>.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-named-graph" class="preserve">named graph</dfn></dt><dd>
     A <a>named graph</a>
     is a <a>linked data graph</a> that is identified by an <a>IRI</a> or <a>blank node</a>.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-node" class="preserve">node</dfn></dt><dd>
-    Every <a>node</a> is an <a>IRI</a>,
-    a <a>blank node</a>,
-    a <a>JSON-LD value</a>,
-    or a <a>list</a>.
-    A piece of information that is represented in a <a>linked data graph</a>.</dd>
+    A <a>node</a> in an <a>RDF graph</a>, made up of the set of <a>subjects</a> and <a>objects</a> of <a>triples</a> in the <a>graph</a>.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-object" class="preserve">object</dfn></dt><dd>
     An <a>object</a> is a <a>node</a> in a <a>linked data graph</a>
     with at least one incoming edge.</dd>
@@ -137,20 +140,16 @@
     Whenever possible, a <a>property</a> should be labeled with an <a>IRI</a>.
     <div class="issue atrisk">The use of <a>blank node identifiers</a> to label properties is obsolete,
       and may be removed in a future version of JSON-LD.</div>
-    See <dfn data-cite="RDF11-CONCEPTS#dfn-predicate" class="preserve">predicate</dfn> in [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-dataset" data-lt="RDF dataset" class="preserve">dataset</dfn></dt><dd>
-    A <a>dataset</a>
-    as specified by [[RDF11-CONCEPTS]]
-    representing a collection of <a data-cite="RDF11-CONCEPTS#dfn-rdf-graph">RDF graphs</a>.</dd>
+    Also, see <dfn data-cite="RDF11-CONCEPTS#dfn-predicate" class="preserve">predicate</dfn> in [[RDF11-CONCEPTS]].</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-resource" class="preserve">resource</dfn></dt><dd>
-    A <a >resource</a> as specified by [[RDF11-CONCEPTS]].</dd>
+    A <a>resource</a> donoted by an <a>IRI</a> or <a>literal</a> representing something in the world ( the "universe of discourse").</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-triple" class="preserve">triple</dfn></dt><dd>
-    A <a>triple</a> as specified by [[RDF11-CONCEPTS]].</dd>
+    A component of an <a>RDF graph</a> including a <a>subject</a>, <a>predicate</a>, and <a>object</a>, which represents
+    a node-arc-node segment of an <a>RDF graph</a>.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-subject" class="preserve">subject</dfn></dt><dd>
     A <a>subject</a> is a <a>node</a> in a <a>linked data graph</a>
     with at least one outgoing edge,
-    related to an <a>object</a> node through a <a>property</a>.
-    See <dfn data-cite="RDF11-CONCEPTS#dfn-subject" class="preserve">RDF subject</dfn> in [[RDF11-CONCEPTS]].</dd>
+    related to an <a>object</a> node through a <a>property</a>.</dd>
 </dl>
 </section>
 

--- a/common/terms.html
+++ b/common/terms.html
@@ -1,4 +1,5 @@
-<section><h3>Terms imported from [[[ECMASCRIPT]]] [[ECMASCRIPT]], [[[RFC8259]]] [[RFC8259]], [[[INFRA]]] [[INFRA]], and [[[WEBIDL]]] [[WEBIDL]]</h3>
+<section><h3>Terms imported from Other Specifications</h3>
+<p>Terms imported from [[[ECMASCRIPT]]] [[ECMASCRIPT]], [[[RFC8259]]] [[RFC8259]], [[[INFRA]]] [[INFRA]], and [[[WEBIDL]]] [[WEBIDL]]</p>
 <dl class="termlist" data-sort>
   <dt><dfn data-cite="INFRA#list" class="preserve">array</dfn></dt><dd>
     In the JSON serialization,
@@ -56,9 +57,8 @@
     wrapped in double quotes, using backslash escapes (if necessary).
     A character is represented as a single character string.</dd>
 </dl>
-</section>
 
-<section><h3>Terms imported from [[[RFC3987]]] [[RFC3987]]</h3>
+<p>Terms imported from [[[RFC3987]]] [[RFC3987]]</p>
 <dl class="termlist" data-sort>
   <dt><dfn data-cite="RFC3987#section-1.3" class="preserve">absolute IRI</dfn></dt><dd>
     An <a>absolute IRI</a>
@@ -76,9 +76,8 @@
     are resolved relative to the <a>vocabulary mapping</a>,
     not the <a>base IRI</a>.</dd>
 </dl>
-</section>
 
-<section><h3>Terms imported from [[[RDF11-CONCEPTS]]] [[RDF11-CONCEPTS]], [[[RDF-SCHEMA]]] [[RDF-SCHEMA]], and [[[LINKED-DATA]]] [[LINKED-DATA]]</h3>
+<p>Terms imported from [[[RDF11-CONCEPTS]]] [[RDF11-CONCEPTS]], [[[RDF-SCHEMA]]] [[RDF-SCHEMA]], and [[[LINKED-DATA]]] [[LINKED-DATA]]</p>
 <dl class="termlist" data-sort>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-base-iri" class="preserve">base IRI</dfn></dt><dd>
     The <a>base IRI</a> is an <a>absolute IRI</a> established in the <a>context</a>,

--- a/common/terms.html
+++ b/common/terms.html
@@ -25,7 +25,7 @@
       composed of <dfn data-cite="INFRA#map-entry" data-lt="map entry|entry" data-ld-noDefault class="preserve">entries</dfn> with key/value pairs.</p>
     <p>In the <a data-cite="JSON-LD11-API#the-application-programming-interface">Application Programming Interface</a>,
       a <a>map</a> is described using a [[WEBIDL]] <a data-cite="WEBIDL#dfn-dictionary">dictionary</a>.</p></dd>
-  <dt class="changed"><dfn data-lt="internal representation">JSON-LD internal representation</dfn></dt><dd class="changed">
+  <dt class="changed"><dfn data-cite="JSON-LD11-API#dfn-internal-representation" data-lt="internal representation">JSON-LD internal representation</dfn></dt><dd class="changed">
     The JSON-LD internal representation
     is the result of transforming a JSON syntactic structure
     into the core data structures suitable for direct processing:
@@ -68,7 +68,7 @@
     An <a>absolute IRI</a>
     is defined in [[RFC3987]] containing a <em>scheme</em> along with a <em>path</em>
     and optional <em>query</em> and fragment segments.</dd>
-  <dt><dfn>active context</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-active-context">active context</dfn></dt><dd>
     A <a>context</a> that is used to resolve <a>terms</a>
     while the processing algorithm is running.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-base-iri" class="preserve">base IRI</dfn></dt><dd>
@@ -86,11 +86,11 @@
     A <a>blank node identifier</a>
     is a string that can be used as an identifier for a <a>blank node</a> within the scope of a JSON-LD document.
     Blank node identifiers begin with <code>_:</code>.</dd>
-  <dt><dfn>compact IRI</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-compact-iri">compact IRI</dfn></dt><dd>
     A compact IRI has the form of <a>prefix</a>:<em>suffix</em>
     and is used as a way of expressing an <a>IRI</a> without needing to define separate <a>term</a> definitions
     for each IRI contained within a common vocabulary identified by <a>prefix</a>.</dd>
-  <dt><dfn>context</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-context">context</dfn></dt><dd>
     A set of rules for interpreting a <a>JSON-LD document</a>
     as specified in the <a data-cite="JSON-LD11#the-context">The Context</a> section of the JSON-LD Syntax specification [[JSON-LD11]].</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-datatype-iri" class="preserve">datatype IRI</dfn></dt><dd>
@@ -99,12 +99,12 @@
     The <a>default graph</a> is the only graph in a JSON-LD document which has no <a>graph name</a>.
     When executing an algorithm,
     the graph where data should be placed if a <a>named graph</a> is not specified.</dd>
-  <dt><dfn>default language</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-default-language">default language</dfn></dt><dd>
     The default language is set in the <a>context</a> using the <code>@language</code> key
     whose value MUST be a <a>string</a> representing a [[BCP47]] language code or <code>null</code>.</dd>
-  <dt><dfn>default object</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-default-object">default object</dfn></dt><dd>
     A <a>default object</a> is a <a>map</a> that has a <code>@default</code> key.</dd>
-  <dt><dfn>embedded context</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-embedded-context">embedded context</dfn></dt><dd>
     An embedded <a>context</a> is a context which appears as part of a
     <a>node object</a>, <a>value object</a>, <a>graph object</a>, <a>list object</a>,
     <a>set object</a>, <span class="changed">or as part of <a>nested properties</a>,
@@ -113,34 +113,34 @@
     Its value may be a <a>map</a> for a <a data-cite="JSON-LD11#dfn-context-definition">context definition</a>,
     as an <a>IRI</a>, or as an <a>array</a> combining either of the above.
   </dd>
-  <dt><dfn class="preserve">scoped context</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-scoped-context" class="preserve">scoped context</dfn></dt><dd>
     A <a>scoped context</a> is part of an <a>expanded term definition</a> using the
     <code>@context</code> <a>entry</a>. It has the same form as an <a>embedded context</a>.
-    When the term is used as a type, it defines a <dfn class="preserve">type-scoped context</dfn>,
-    when used as a property it defines a <dfn class="preserve">property-scoped context</dfn>.
+    When the term is used as a type, it defines a <dfn data-cite="JSON-LD11#dfn-type-scoped-context" class="preserve">type-scoped context</dfn>,
+    when used as a property it defines a <dfn data-cite="JSON-LD11#dfn-property-scoped-context" class="preserve">property-scoped context</dfn>.
   </dd>
-  <dt><dfn>expanded term definition</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-expanded-term-definition">expanded term definition</dfn></dt><dd>
     An expanded term definition is a <a>term definition</a>
     where the value is a <a>map</a>
     containing one or more <a>keyword</a> keys to define the associated <a>absolute IRI</a>,
     if this is a reverse property,
     the type associated with string values, and a container mapping.</dd>
-  <dt><dfn data-lt="frame|JSON-LD frame">frame</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-frame" data-lt="frame|JSON-LD frame">frame</dfn></dt><dd>
     A <a>JSON-LD document</a>,
     which describes the form for transforming another <a>JSON-LD document</a>
     using matching and embedding rules.
     A frame document allows additional keywords and certain <a>map entries</a>
     to describe the matching and transforming process.</dd>
-  <dt><dfn data-lt="json-ld processor|Processors">JSON-LD Processor</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-API#dfn-json-ld-processor" data-lt="json-ld processor|Processors">JSON-LD Processor</dfn></dt><dd>
     A <a>JSON-LD Processor</a> is a system which can perform the algorithms defined in [[JSON-LD11-API]].</dd>
-  <dt><dfn>frame object</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-frame-object">frame object</dfn></dt><dd>
     A frame object is a <a>map</a> element within a <a>frame</a>
     which represents a specific portion of the <a>frame</a> matching either
     a <a>node object</a> or a <a>value object</a>
     in the input.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-graph-name" class="preserve">graph name</dfn></dt><dd>
     The <a>IRI</a> or <a>blank node</a> identifying a <a>named graph</a>.</dd>
-  <dt class="changed"><dfn>id map</dfn></dt><dd class="changed">
+  <dt class="changed"><dfn data-cite="JSON-LD11#dfn-id-map">id map</dfn></dt><dd class="changed">
     An <a>id map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@id</code>.
     The values of the <a>id map</a> MUST be <a>node objects</a>,
@@ -148,18 +148,18 @@
     the <code>@id</code> of the associated <a>node object</a>.
     If a value in the <a>id map</a> contains a key expanding to <code>@id</code>,
     it's value MUST be equivalent to the referencing key in the <a>id map</a>.</dd>
-  <dt class="changed"><dfn>graph object</dfn></dt><dd class="changed">
+  <dt class="changed"><dfn data-cite="JSON-LD11#dfn-graph-object">graph object</dfn></dt><dd class="changed">
     A <a>graph object</a> represents a <a>named graph</a>
     as the value of a <a>map entry</a> within a <a>node object</a>.
     When expanded, a graph object MUST have an <code>@graph</code> <a>entry</a>,
     and MAY also have <code>@id</code>, and <code>@index</code> <a>entries</a>.
-    A <dfn class="preserve">simple graph object</dfn>
+    A <dfn data-cite="JSON-LD11#dfn-simple-graph-object" class="preserve">simple graph object</dfn>
     is a <a>graph object</a> which does not have an <code>@id</code> <a>entry</a>.
     Note that <a>node objects</a> may have a <code>@graph</code> <a>entry</a>,
     but are not considered <a>graph objects</a> if they include any other <a>entries</a>.
     A top-level object consisting of <code>@graph</code> is also not a <a>graph object</a>.
     Note that a <a>node object</a> may also represent a <a>named graph</a> it it includes other properties.</dd>
-  <dt><dfn>index map</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-index-map">index map</dfn></dt><dd>
     An <a>index map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@index</code>,
     whose values MUST be any of the following types:
@@ -174,25 +174,25 @@
     <a>set object</a>, or
     an <a>array</a> of zero or more of the above possibilities.
   </dd>
-  <dt><dfn data-lt="IRI|Internationalized Resource Identifier" class="preserve"><abbr title="Internationalized Resource Identifier">IRI</abbr></dfn></dt><dd>
-    An <a data-cite="RFC3987#section-1.3" class="externalDFN">Internationalized Resource Identifier</a>
+  <dt><dfn data-cite="RFC3987#section-1.3" data-lt="IRI|Internationalized Resource Identifier" class="preserve"><abbr title="Internationalized Resource Identifier">IRI</abbr></dfn></dt><dd>
+    An <a>Internationalized Resource Identifier</a>
     as described in [[RFC3987]].</dd>
-  <dt><dfn>JSON-LD document</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-json-ld-document">JSON-LD document</dfn></dt><dd>
     A <a>JSON-LD document</a> is a serialization of
     a collection of <a>graphs</a>
     and comprises exactly one <a>default graph</a> and zero or more <a>named graphs</a>.</dd>
-  <dt><dfn class="preserve">JSON-LD value</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-json-ld-value" class="preserve">JSON-LD value</dfn></dt><dd>
     A <a>JSON-LD value</a> is a <a>string</a>,
     a <a>number</a>,
     <code>true</code> or <code>false</code>,
     a <a>typed value</a>,
     or a <a>language-tagged string</a>.
   </dd>
-  <dt><dfn>keyword</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-keyword">keyword</dfn></dt><dd>
     A <a>string</a> that is specific to JSON-LD,
     specified in the JSON-LD Syntax specification [[JSON-LD11]]
     in the section titled <a data-cite="JSON-LD11#syntax-tokens-and-keywords">Syntax Tokens and Keywords</a>.</dd>
-  <dt><dfn>language map</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-language-map">language map</dfn></dt><dd>
     An <a>language map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@language</code>,
     whose keys MUST be <a>strings</a> representing [[BCP47]] language codes
@@ -215,22 +215,22 @@
     i.e., a set of <a>nodes</a> connected by directed-arcs.</dd>
   <dt><dfn data-cite="RDF-SCHEMA#ch_collectionvocab" data-lt="collection|RDF collection" class="preserve">list</dfn></dt><dd>
     A <a>list</a> is an ordered sequence of <a>IRIs</a>, <a>blank nodes</a>, and <a>JSON-LD values</a>.</dd>
-  <dt><dfn>list object</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-list-object">list object</dfn></dt><dd>
     A <a>list object</a> is a <a>map</a> that has a <code>@list</code> key.
     It may also have an <code>@index</code> key, but no other <a>entries</a>.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-literal" data-lt="RDF literal" class="preserve">literal</dfn></dt><dd>
     An <a>object</a> expressed as a value such as a string or number, or in expanded form as a <a>value object</a>.</dd>
-  <dt><dfn>local context</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-local-context">local context</dfn></dt><dd>
     A <a>context</a> that is specified with a <a>map</a>,
     specified via the <code>@context</code> <a>keyword</a>.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-named-graph" class="preserve">named graph</dfn></dt><dd>
     A <a>named graph</a>
     is a <a>linked data graph</a> that is identified by an <a>IRI</a> or <a>blank node</a>.</dd>
-  <dt><dfn>implicitly named graph</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-implicitly-named-graph">implicitly named graph</dfn></dt><dd>
     A <a>named graph</a> created from the value of a <a>map entry</a>
     having an <a>expanded term definition</a>
     where <code>@container</code> is set to  <code>@graph</code>.</dd>
-  <dt><dfn>nested property</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-nested-property">nested property</dfn></dt><dd>
     A <a>nested property</a> is a key in a <a>node object</a>
     whose value is a <a>map</a> containing <a>entries</a> which are treated as if they were values of the <a>node object</a>.
     The <a>nested property</a> itself is semantically meaningless and used only to create a sub-structure within a <a>node object</a>.
@@ -241,7 +241,7 @@
     a <a>JSON-LD value</a>,
     or a <a>list</a>.
     A piece of information that is represented in a <a>linked data graph</a>.</dd>
-  <dt><dfn>node object</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-node-object">node object</dfn></dt><dd>
     A <a>node object</a> represents zero or more <a>properties</a> of a <a>node</a> in the <a>graph</a>
     serialized by the <a>JSON-LD document</a>.
     A <a>map</a> is a <a>node object</a>
@@ -253,18 +253,18 @@
     </ul>
     The <a>entries</a> of a <a>node object</a> whose keys are not keywords are also called <a>properties</a> of the <a>node object</a>.
   </dd>
-  <dt><dfn>node reference</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-node-reference">node reference</dfn></dt><dd>
     A <a>node object</a> used to reference a node having only the <code>@id</code> key.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-object" class="preserve">object</dfn></dt><dd>
     An <a>object</a> is a <a>node</a> in a <a>linked data graph</a>
     with at least one incoming edge.
     See <dfn data-cite="RDF11-CONCEPTS#dfn-object" class="preserve">RDF object</dfn> in [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn>prefix</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-prefix">prefix</dfn></dt><dd>
     A <a>prefix</a> is the first component of a <a>compact IRI</a>
     which comes from a <a>term</a> that maps to a string that,
     when prepended to the suffix of the <a>compact IRI</a>,
     results in an <a>absolute IRI</a>.</dd>
-  <dt><dfn>processing mode</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-processing-mode">processing mode</dfn></dt><dd>
     The processing mode defines how a JSON-LD document is processed.
     By default, all documents are assumed to be conformant with <a data-cite="JSON-LD" data-no-xref="">JSON-LD 1.0</a> [[JSON-LD]].
     By defining a different version using the <code>@version</code> <a>entry</a> in a <a>context</a>,
@@ -295,7 +295,7 @@
     and values of <a>terms</a> defined to be <em>vocabulary relative</em>
     are resolved relative to the <a>vocabulary mapping</a>,
     not the <a>base IRI</a>.</dd>
-  <dt><dfn>set object</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-set-object">set object</dfn></dt><dd>
     A <a>set object</a> is a <a>map</a> that has an <code>@set</code> <a>entry</a>.
     It may also have an <code>@index</code> key, but no other <a>entries</a>.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-subject" class="preserve">subject</dfn></dt><dd>
@@ -303,20 +303,20 @@
     with at least one outgoing edge,
     related to an <a>object</a> node through a <a>property</a>.
     See <dfn data-cite="RDF11-CONCEPTS#dfn-subject" class="preserve">RDF subject</dfn> in [[RDF11-CONCEPTS]].</dd>
-  <dt><dfn>term</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-term">term</dfn></dt><dd>
     A <a>term</a> is a short word defined in a <a>context</a>
     that MAY be expanded to an <a>IRI</a>.
   </dd>
-  <dt><dfn>term definition</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-term-definition">term definition</dfn></dt><dd>
     A term definition is an entry in a <a>context</a>,
     where the key defines a <a>term</a>
     which may be used within a <a>map</a>
     as a key, type, or elsewhere that a string is interpreted as a vocabulary item.
-    Its value is either a string (<dfn data-lt="simple term">simple term definition</dfn>),
+    Its value is either a string (<dfn data-cite="JSON-LD11#dfn-simple-term-definition" data-lt="simple term">simple term definition</dfn>),
     expanding to an absolute IRI,
     or an <a>expanded term definition</a>.
   </dd>
-  <dt class="changed"><dfn>type map</dfn></dt><dd class="changed">
+  <dt class="changed"><dfn data-cite="JSON-LD11#dfn-type-map">type map</dfn></dt><dd class="changed">
     An <a>type map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@type</code>,
     whose keys are interpreted as <a>IRIs</a>
@@ -324,20 +324,20 @@
     the value MUST be a <a>node object</a>, or <a>array</a> of node objects.
     If the value contains a <a>term</a> expanding to <code>@type</code>,
     it's values are merged with the map value when expanding.</dd>
-  <dt><dfn>JSON literal</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-json-literal">JSON literal</dfn></dt><dd>
     A <a>JSON literal</a> is a <a>literal</a> where the associated <a>IRI</a> is <code>rdf:JSON</code>.
     In the <a>value object</a> representation, the value of <code>@type</code> is <code>@json</code>.
     JSON literals represent values which are valid JSON [[RFC8259]].
-    See <dfn data-cite="JSON-LD11#dfn-json-datatype" class="preserve">JSON datatype</dfn> in [[JSON-LD11]].
+    See <dfn data-cite="JSON-LD11#dfn-json-datatype" data-cite="JSON-LD11#dfn-json-datatype" class="preserve">JSON datatype</dfn> in [[JSON-LD11]].
   </dd>
-  <dt><dfn class="preserve">typed value</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-typed-value" class="preserve">typed value</dfn></dt><dd>
     A <a>typed value</a> consists of a value,
     which is a <a>string</a>,
     and a type,
     which is an <a>IRI</a>.</dd>
-  <dt><dfn>value object</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-value-object">value object</dfn></dt><dd>
     A <a>value object</a> is a <a>map</a> that has an <code>@value</code> <a>entry</a>.</dd>
-  <dt><dfn class="preserve">vocabulary mapping</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-vocabulary-mapping" class="preserve">vocabulary mapping</dfn></dt><dd>
     The vocabulary mapping is set in the <a>context</a> using the <code>@vocab</code> key
     whose value MUST be an <a>IRI</a> or <code>null</code>.</dd>
 </dl>

--- a/index.html
+++ b/index.html
@@ -325,7 +325,7 @@
   <p>JSON-LD is designed to be usable directly as JSON, with no knowledge of RDF
    [[RDF11-CONCEPTS]]. It is also designed to be usable as RDF, if desired, for
    use with other Linked Data technologies like SPARQL [[SPARQL11-OVERVIEW]]. Developers who
-   require any of the facilities listed above or need to serialize an RDF <a>Graph</a>
+   require any of the facilities listed above or need to serialize an <a>RDF graph</a>
    or <a>Dataset</a> in a JSON-based syntax will find JSON-LD of interest. People
    intending to use JSON-LD with RDF tools will find it can be used as another
    RDF syntax, as with [[Turtle]] and [[TriG]]. Complete details of how JSON-LD relates
@@ -353,7 +353,7 @@
       <li>Software developers who want to implement processors and APIs for
         JSON-LD</li>
       <li>Software developers who want to generate or consume Linked Data,
-        an RDF <a>graph</a>, or an <a>RDF Dataset</a> in a JSON syntax</li>
+        an <a>RDF graph</a>, or an <a>RDF Dataset</a> in a JSON syntax</li>
     </ul>
 
     <p>A companion document, the JSON-LD 1.1 Processing Algorithms and API specification
@@ -403,8 +403,8 @@
   <section class="normative">
     <h2>Terminology</h2>
 
-    <p>This document uses the following terms as defined in JSON [[RFC8259]]. Refer
-      to the <a data-cite="RFC8259#section-2">JSON Grammar section</a> in [[RFC8259]] for formal definitions.</p>
+    <p>This document uses the following terms as defined in external specifications
+      and defines terms specific to JSON-LD.</p>
 
     <!-- FIXME: restrictReferences stopped working properly, so removing for now. -->
     <div data-include="common/terms.html"></div>
@@ -1290,7 +1290,7 @@
   <h2>Node Identifiers</h2>
 
   <p>To be able to externally reference <a>nodes</a>
-    in a <a>graph</a>, it is important that
+    in an <a>RDF graph</a>, it is important that
     <a>nodes</a> have an identifier. <a>IRIs</a>
     are a fundamental concept of Linked Data, for
     <a>nodes</a> to be truly linked, dereferencing the
@@ -12265,7 +12265,7 @@ the data type to be specified explicitly with each piece of data.</p>
   <ul>
     <li>In JSON-LD <a>properties</a> can be
       <a>IRIs</a> or <a>blank nodes</a>
-      whereas in RDF properties (predicates) have to be <a>IRIs</a>. This
+      whereas in RDF properties (<a>predicates</a>) have to be <a>IRIs</a>. This
       means that JSON-LD serializes
       <a>generalized RDF Datasets</a>.</li>
     <li>In JSON-LD <a>lists</a> use native JSON syntax, either contained in a
@@ -12306,7 +12306,7 @@ the data type to be specified explicitly with each piece of data.</p>
 
   <p>Even though JSON-LD serializes
     <a>RDF Datasets</a>, it can
-    also be used as a <dfn data-cite="RDF11-CONCEPTS#dfn-rdf-source">RDF graph source</dfn>.
+    also be used as a <dfn data-cite="RDF11-CONCEPTS#dfn-rdf-source">graph source</dfn>.
     In that case, a consumer MUST only use the <a>default graph</a> and ignore all <a>named graphs</a>.
     This allows servers to expose data in languages such as Turtle and JSON-LD
     using content negotiation.</p>
@@ -12414,7 +12414,7 @@ the data type to be specified explicitly with each piece of data.</p>
       inverse of this last step, creating an expanded JSON-LD document closely
       matching the triples from RDF, using a single <a>node object</a>
       for all triples having a common subject, and a single <a>property</a>
-      for those triples also having a common predicate. The result may
+      for those triples also having a common <a>predicate</a>. The result may
       then be framed by using the
       <a data-cite="JSON-LD11-FRAMING#framing-algorithm">Framing Algorithm</a>
       described in [[JSON-LD11-FRAMING]] to create the desired object embedding.</p>
@@ -12423,7 +12423,7 @@ the data type to be specified explicitly with each piece of data.</p>
   <section class="changed"><h2>The <code>rdf:JSON</code> Datatype</h2>
     <p>RDF provides for JSON content as a possible <a data-lt="RDF literal">literal value</a>.
       This allows markup in literal values.
-      Such content is indicated in an <a>RDF graph</a> using a <a>literal</a> whose datatype is set to <code>rdf:JSON</code>.</p>
+      Such content is indicated in a <a>graph</a> using a <a>literal</a> whose datatype is set to <code>rdf:JSON</code>.</p>
 
     <p>The <code>rdf:JSON</code> datatype is defined as follows:</p>
 
@@ -12550,7 +12550,7 @@ the data type to be specified explicitly with each piece of data.</p>
   <section id="fig-linked-data-graph-descr"><h3>Linked Data Dataset</h3>
       <h2>Description of the <a href="#fig-linked-data-graph">Linked Data Dataset figure</a> in <a href="#data-model" class="sectionRef"></a></h2>
       <p>The image consists of three dashed boxes, each describing a different
-        linked data graph. Each box consists of shapes linked with arrows describing
+        <a>linked data graph</a>. Each box consists of shapes linked with arrows describing
         the linked data relationships.</p>
       <p>The first box is titled "default graph: &lt;no name&gt;" describes two
         resources: <code>http://example.com/people/alice</code> and <code>http://example.com/people/bob</code>

--- a/index.html
+++ b/index.html
@@ -12336,7 +12336,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <li>Flatten the document, which turns the document into an array of
         <a>node objects</a>. Flattening is discussed
         further in <a class="sectionRef" href="#flattened-document-form"></a>.</li>
-      <li>Turn each <a>node object</a> into a series of <a>RDF triples</a>.</li>
+      <li>Turn each <a>node object</a> into a series of <a>triples</a>.</li>
     </ol>
 
     <p>For example, consider the following JSON-LD document in compact form:</p>
@@ -12390,7 +12390,7 @@ the data type to be specified explicitly with each piece of data.</p>
     </pre>
 
     <p>Deserializing this to RDF now is a straightforward process of turning
-      each <a>node object</a> into one or more RDF triples. This can be
+      each <a>node object</a> into one or more <a>triples</a>. This can be
       expressed in Turtle as follows:</p>
 
     <pre class="example" data-transform="updateExample"


### PR DESCRIPTION
* Reorganize and re-introduce terms.
* Add explicit `data-cite` on all defined terms, to localize them to a particular spec.
* Simplifies some imported terms.

@pchampin see if this is what you had in mind. We could consolidate all imported terms.

@marcoscaceres this adds a `data-cite` to each shared term we define, which seems like what we need to do.

Fixes #185.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/206.html" title="Last updated on Jul 20, 2019, 9:54 PM UTC (1121d34)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/206/cadf696...1121d34.html" title="Last updated on Jul 20, 2019, 9:54 PM UTC (1121d34)">Diff</a>