### PR TITLE
Update restrictReferences logic for removing unused definitions.

### DIFF
--- a/index.html
+++ b/index.html
@@ -406,8 +406,9 @@
     <p>This document uses the following terms as defined in external specifications
       and defines terms specific to JSON-LD.</p>
 
-    <!-- FIXME: restrictReferences stopped working properly, so removing for now. -->
-    <div data-include="common/terms.html"></div>
+    <div data-include="common/terms.html"
+         data-oninclude="restrictReferences">
+    </div>
   </section>
 
   <section class="informative">


### PR DESCRIPTION
Remove unused definitions not defined in this spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/215.html" title="Last updated on Aug 27, 2019, 10:56 PM UTC (512ca06)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/215/413ebc8...512ca06.html" title="Last updated on Aug 27, 2019, 10:56 PM UTC (512ca06)">Diff</a>