### PR TITLE
Azaroth suggestions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ruby-rdf/json-ld.git
-  revision: 172e0c960c9771fa9f963eca55d28fb63bce56b0
+  revision: adbd407fa4b5783c8a7f7b79653b6e38815ff854
   branch: develop
   specs:
     json-ld (3.0.2)
@@ -14,8 +14,8 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     bcp47 (0.3.3)
       i18n
     builder (3.2.3)
@@ -28,7 +28,7 @@ GEM
       sxp (~> 1.0)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
-    haml (5.1.1)
+    haml (5.1.2)
       temple (>= 0.8.0)
       tilt
     hamster (3.0.0)
@@ -37,7 +37,7 @@ GEM
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     json-canonicalization (0.1.0)
-    json-ld-preloaded (3.0.3)
+    json-ld-preloaded (3.0.4)
       json-ld (~> 3.0)
       multi_json (~> 1.12)
       rdf (~> 3.0)
@@ -77,11 +77,11 @@ GEM
     multi_json (1.13.1)
     net-http-persistent (3.1.0)
       connection_pool (~> 2.2)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     nokogumbo (1.5.0)
       nokogiri
-    public_suffix (3.1.1)
+    public_suffix (4.0.1)
     rack (2.0.7)
     rake (12.3.3)
     rdf (3.0.12)
@@ -135,7 +135,7 @@ GEM
     rdf-turtle (3.0.6)
       ebnf (~> 1.1)
       rdf (~> 3.0)
-    rdf-vocab (3.0.8)
+    rdf-vocab (3.0.10)
       rdf (~> 3.0, >= 3.0.11)
     rdf-xsd (3.0.1)
       rdf (~> 3.0)
@@ -160,8 +160,8 @@ GEM
       rdf (~> 3.0)
     sxp (1.0.2)
       rdf (~> 3.0)
-    temple (0.8.1)
-    tilt (2.0.9)
+    temple (0.8.2)
+    tilt (2.0.10)
 
 PLATFORMS
   ruby

--- a/common/common.js
+++ b/common/common.js
@@ -33,14 +33,23 @@ function restrictReferences(utils, content) {
   return (base.innerHTML);
 }
 
-// add a handler to come in after all the definitions are resolved
-//
-// New logic: If the reference is within a 'dl' element of
-// class 'termlist', and if the target of that reference is
-// also within a 'dl' element of class 'termlist', then
-// consider it an internal reference and ignore it.
 require(["core/pubsubhub"], (respecEvents) => {
   "use strict";
+
+// remote data-cite on where the citation is to ourselves.
+  respecEvents.sub('end', (message) => {
+    const selfDfns = document.querySelectorAll("dfn[data-cite^='" + respecConfig.shortName.toUpperCase() + "']");
+    for (const dfn of selfDfns) {
+      delete dfn.dataset.cite;
+    }
+  });
+
+  // add a handler to come in after all the definitions are resolved
+  //
+  // New logic: If the reference is within a 'dl' element of
+  // class 'termlist', and if the target of that reference is
+  // also within a 'dl' element of class 'termlist', then
+  // consider it an internal reference and ignore it.
   respecEvents.sub('end', (message) => {
     if (message === 'core/link-to-dfn') {
       // all definitions are linked; find any internal references

--- a/common/terms.html
+++ b/common/terms.html
@@ -224,7 +224,7 @@
     and its keys are interpreted as <a>IRIs</a> representing
     the <code>@id</code> of the associated <a>node object</a>.
     If a value in the <a>id map</a> contains a key expanding to <code>@id</code>,
-    it's value MUST be equivalent to the referencing key in the <a>id map</a>.</dd>
+    its value MUST be equivalent to the referencing key in the <a>id map</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-implicitly-named-graph">implicitly named graph</dfn></dt><dd>
     A <a>named graph</a> created from the value of a <a>map entry</a>
     having an <a>expanded term definition</a>
@@ -345,7 +345,7 @@
     representing the <code>@type</code> of the associated <a>node object</a>;
     the value MUST be a <a>node object</a>, or <a>array</a> of node objects.
     If the value contains a <a>term</a> expanding to <code>@type</code>,
-    it's values are merged with the map value when expanding.</dd>
+    its values are merged with the map value when expanding.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-typed-value" class="preserve">typed value</dfn></dt><dd>
     A <a>typed value</a> consists of a value,
     which is a <a>string</a>,

--- a/common/terms.html
+++ b/common/terms.html
@@ -169,7 +169,8 @@
     A set of rules for interpreting a <a>JSON-LD document</a>
     as specified in the <a data-cite="JSON-LD11#the-context">The Context</a> section of JSON-LD 1.1.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-default-language">default language</dfn></dt><dd>
-    The default language is set in the <a>context</a> using the <code>@language</code> key
+    The <a>default language</a> is the language used when a string does not have a language associated with it directly.
+    It can be set in the <a>context</a> using the <code>@language</code> key
     whose value MUST be a <a>string</a> representing a [[BCP47]] language code or <code>null</code>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-default-object">default object</dfn></dt><dd>
     A <a>default object</a> is a <a>map</a> that has a <code>@default</code> key.</dd>

--- a/common/terms.html
+++ b/common/terms.html
@@ -231,7 +231,7 @@
     where <code>@container</code> is set to  <code>@graph</code>.</dd>
   <dt class="changed"><dfn data-cite="JSON-LD11#dfn-included-block">included block</dfn></dt><dd class="changed">
     An <a>included block</a> is an <a>entry</a> in a <a>node object</a> where the key is either `@included` or an alias of `@included`
-    and the value is one ore more <a>node objects</a>.</dd>
+    and the value is one or more <a>node objects</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-index-map">index map</dfn></dt><dd>
     An <a>index map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@index</code>,

--- a/index.html
+++ b/index.html
@@ -6500,9 +6500,7 @@ the data type to be specified explicitly with each piece of data.</p>
   </aside>
 
   <p>A <a>node object</a>, like the one used above, may be used in
-    any value position in the body of a JSON-LD document. Note that <a
-    href="#type-coercion">type coercion</a> of the <code>knows</code> property
-    is not required, as the value is not a string.</p>
+    any value position in the body of a JSON-LD document.</p>
 
   <p>While it is considered a best practice to identify nodes in a graph,
     at times this is impractical. In the data model, nodes without an explicit

--- a/index.html
+++ b/index.html
@@ -2947,7 +2947,7 @@
 
   <p class="changed">In this case, the <em>property</em> term would not normally be usable as a prefix, both
     because it is defined with an <a>expanded term definition</a>, and because
-    it's <code>@id</code> does not end in a
+    its <code>@id</code> does not end in a
     <a data-cite="RFC3986#section-2.2">gen-delim</a> character. Adding
     <code>"@prefix": true</code> allows it to be used as the prefix portion of
     the <a>compact IRI</a> <em>property:One</em>.</p>
@@ -12056,7 +12056,7 @@ the data type to be specified explicitly with each piece of data.</p>
       or a <a>term</a> which expands to <code>@none</code>,
       and the values MUST be <a>node objects</a>.</p>
 
-    <p>If the value contains a property expanding to <code>@id</code>, it's value MUST
+    <p>If the value contains a property expanding to <code>@id</code>, its value MUST
       be equivalent to the referencing key. Otherwise, the property from the value is used as
       the <code>@id</code> of the <a>node object</a> value when expanding.</p>
 
@@ -12082,7 +12082,7 @@ the data type to be specified explicitly with each piece of data.</p>
       and the values MUST be <a>node objects</a>
       or <a>strings</a> which expand to <a>node objects</a>.</p>
 
-    <p>If the value contains a property expanding to <code>@type</code>, and it's value
+    <p>If the value contains a property expanding to <code>@type</code>, and its value
       is contains the referencing key after suitable expansion of both the referencing key
       and the value, then the <a>node object</a> already contains the type. Otherwise, the property from the value is
       added as a <code>@type</code> of the <a>node object</a> value when expanding.</p>

--- a/index.html
+++ b/index.html
@@ -4694,9 +4694,10 @@ the data type to be specified explicitly with each piece of data.</p>
     "@context": {
       "@base": "http://example1.com/",
       "@vocab": "http://example2.com/",
-      "fred": {"@type": "@vocab"}
+      "knows": {"@type": "@vocab"}
     },
-    "fred": [
+    "@id": "fred",
+    "knows": [
       {"@id": "barney", "mnemonic": "the sidekick"},
       "barney"
     ]
@@ -4708,15 +4709,13 @@ the data type to be specified explicitly with each piece of data.</p>
        data-result-for="Term expansion for values, not identifiers-compacted">
   <!--
   [{
-    "http://example2.com/fred": [
-      {
-        "@id": "http://example1.com/barney",
-        "http://example2.com/mnemonic": [{"@value": "the sidekick"}]
-      },
-      {
-        "@id": "http://example2.com/barney"
-      }
-    ]
+    "@id": "http://example1.com/fred",
+    "http://example2.com/knows": [{
+      "@id": "http://example1.com/barney",
+      "http://example2.com/mnemonic": [{"@value": "the sidekick"}]
+    }, {
+      "@id": "http://example2.com/barney"
+    }]
   }]
   -->
   </pre>
@@ -4726,8 +4725,8 @@ the data type to be specified explicitly with each piece of data.</p>
     <thead><tr><th>Subject</th><th>Property</th><th>Value</th></tr></thead>
     <tbody>
       <tr><td>http://example1.com/barney</td><td>http://example2.com/mnemonic</td><td>the sidekick</td></tr>
-      <tr><td>_:b0</td><td>http://example2.com/fred</td><td>http://example1.com/barney</td></tr>
-      <tr><td>_:b0</td><td>http://example2.com/fred</td><td>http://example2.com/barney</td></tr>
+      <tr><td>http://example1.com/fred</td><td>http://example2.com/knows</td><td>http://example1.com/barney</td></tr>
+      <tr><td>http://example1.com/fred</td><td>http://example2.com/knows</td><td>http://example2.com/barney</td></tr>
     </tbody>
   </table>
   <pre class="turtle"
@@ -4742,7 +4741,7 @@ the data type to be specified explicitly with each piece of data.</p>
 
   ex1:barney ex2:mnemonic "the sidekick" .
 
-  [ ex2:fred ex2:barney, ex1:barney] .
+  ex1:fred ex2:knows ex1:barney, ex2:barney .
   -->
   </pre>
 </aside>
@@ -4765,7 +4764,7 @@ the data type to be specified explicitly with each piece of data.</p>
   of <code>@vocab</code> illustrates the behavior of interpreting "barney" relative to the document:</p>
 
 
-<aside class="example ds-selector-tabs changed"
+<aside class="example ds-selector-tabs"
        title="Terms not expanded when document-relative">
   <div class="selectors">
     <button class="selected" data-selects="compacted">Compacted (Input)</button>
@@ -4780,9 +4779,10 @@ the data type to be specified explicitly with each piece of data.</p>
     "@context": {
       "@base": "http://example1.com/",
       "@vocab": "http://example2.com/",
-      "fred": {"@type": "@id"}
+      "knows": {"@type": "@id"}
     },
-    "fred": [
+    "@id": "fred",
+    "knows": [
       {"@id": "barney", "mnemonic": "the sidekick"},
       "barney"
     ]
@@ -4794,15 +4794,13 @@ the data type to be specified explicitly with each piece of data.</p>
        data-result-for="Terms not expanded when document-relative-compacted">
   <!--
   [{
-    "http://example2.com/fred": [
-      {
-        "@id": "http://example1.com/barney",
-        "http://example2.com/mnemonic": [{"@value": "the sidekick"}]
-      },
-      {
-        "@id": "http://example1.com/barney"
-      }
-    ]
+    "@id": "http://example1.com/fred",
+    "http://example2.com/knows": [{
+      "@id": "http://example1.com/barney",
+      "http://example2.com/mnemonic": [{"@value": "the sidekick"}]
+    }, {
+      "@id": "http://example1.com/barney"
+    }]
   }]
   -->
   </pre>
@@ -4818,7 +4816,7 @@ the data type to be specified explicitly with each piece of data.</p>
 
   ex1:barney ex2:mnemonic "the sidekick" .
 
-  [] ex2:fred ex1:barney, ex1:barney .
+  ex1:fred ex2:knows, ex1:barney .
   -->
   </pre>
 </aside>
@@ -4831,7 +4829,7 @@ the data type to be specified explicitly with each piece of data.</p>
   to be applied to keys which are not represented as a simple <a>term</a>.
   For example:</p>
 
-<aside class="example ds-selector-tabs changed"
+<aside class="example ds-selector-tabs"
        title="Term definitions using compact and absolute IRIs">
   <div class="selectors">
     <button class="selected" data-selects="compacted">Compacted (Input)</button>

--- a/index.html
+++ b/index.html
@@ -267,7 +267,7 @@
 <body>
 <section id="abstract">
   <p>JSON is a useful data serialization and messaging format.
-    This specification defines JSON-LD, a JSON-based format to serialize
+    This specification defines JSON-LD 1.1, a JSON-based format to serialize
     Linked Data. The syntax is designed to easily integrate into deployed
     systems that already use JSON, and provides a smooth upgrade path from
     JSON to JSON-LD.

--- a/index.html
+++ b/index.html
@@ -3544,7 +3544,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     <a>context</a> removes it by setting `@context` to `null`,
     or by redefining terms,
     with the exception of <a>type-scoped contexts</a>,
-    which limits the effect of that context until the next <a>node object</a> is entered.
+    which limit the effect of that context until the next <a>node object</a> is entered.
     This behavior can be changed using the `@propagate` keyword.</p>
 
   <p>The following example illustrates how terms defined in a context with `@propagate` set to `false`

--- a/index.html
+++ b/index.html
@@ -4816,7 +4816,7 @@ the data type to be specified explicitly with each piece of data.</p>
 
   ex1:barney ex2:mnemonic "the sidekick" .
 
-  ex1:fred ex2:knows, ex1:barney .
+  ex1:fred ex2:knows ex1:barney, ex1:barney .
   -->
   </pre>
 </aside>
@@ -5001,6 +5001,8 @@ the data type to be specified explicitly with each piece of data.</p>
   {
     "@context": {
       ####...####
+      ****"@version": 1.1,****
+      "@vocab": "http://example.com/",
       "@language": "ja",
       "details": {
         ****"@context": {

--- a/index.html
+++ b/index.html
@@ -587,7 +587,7 @@
       <dt class="changed"><code>@nest</code></dt><dd class="changed">Used to define a <a>property</a> of a <a>node object</a> that groups together properties of that node, but is not an edge in the graph.</dd>
       <dt class="changed"><code>@none</code></dt><dd class="changed">Used as an index value
         in an <a>index map</a>, <a>id map</a>, <a>language map</a>, <a>type map</a>, or elsewhere where a <a>map</a> is
-        used to index into other values.</dd>
+        used to index into other values, when the indexed node does not have the feature being indexed.</dd>
       <dt class="changed"><code>@prefix</code></dt><dd class="changed">
         With the value <code>true</code>, allows this <a>term</a> to be used to construct a <a>compact IRI</a>
         when compacting.</dd>

--- a/index.html
+++ b/index.html
@@ -1369,7 +1369,14 @@
       See <a class="sectionRef" href="#describing-values"></a> for more information,
       and <a class="sectionRef" href="#value-objects"></a> for the normative definition.
     </dd>
-    <dt><a>List Objects</a> and <a>Set objects</a></dt><dd></dd>
+    <dt><a>List Objects</a> and <a>Set objects</a></dt><dd>
+      <a>List Objects</a> are a special kind of JSON-LD <a>maps</a>,
+      distinct from <a>node objects</a> and <a>value objects</a>,
+      used to express ordered values by wrapping an <a>array</a> in a <a>map</a> under the key `@list`.
+      <a>Set Objects</a> exist for uniformity, and are equivalent to the array value of the `@set` key.
+      See <a href="#lists" class="sectionRef"></a> and <a href="#sets" class="sectionRef"></a>
+      for more detail.
+    </dd>
     <dt>Map Objects</dt><dd>
       JSON-LD uses various forms of <a>maps</a> as ways to more easily access values of a <a>property</a>.
       <dl>

--- a/index.html
+++ b/index.html
@@ -3527,10 +3527,10 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
   </pre>
 
   <p class="note">If a <a>term</a> defines a <a>scoped context</a>,
-    and then that term is later re-defined,
+    and then that term is later redefined,
     the association of the context defined in the earlier
     <a>expanded term definition</a> is lost
-    within the scope of that re-definition. This is consistent with
+    within the scope of that redefnition. This is consistent with
     <a>term definitions</a> of a term overriding previous term definitions from
     earlier less deeply nested definitions, as discussed in
     <a href="#advanced-context-usage" class="sectionRef"></a>.</p>

--- a/index.html
+++ b/index.html
@@ -3731,7 +3731,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
   </pre>
 
   <p>Similarly, the wrapping <a>context</a> may replace term definitions or
-    set other context-wide keywords that may effect how the imported
+    set other context-wide keywords that may affect how the imported
     <a>context</a> term definitions will be processed:</p>
 
   <pre class="example nohighlight" data-transform="updateExample"

--- a/index.html
+++ b/index.html
@@ -471,13 +471,16 @@
       The graph contains <a>nodes</a>, which are connected by directed-arcs.
       A node is either a <a>resource</a> with <a>properties</a>, or the data values of those properties including
       <a>strings</a>, <a>numbers</a>, <a>typed values</a> (like dates and times) and <a>IRIs</a>.</p>
-    <p class="changed">Within a directed graph, nodes may
-      be <em>unnamed</em>, i.e., not identified by an <a>IRI</a> or representing
-      data such as <a>strings</a> or <a>numbers</a>. Such nodes are called <a>blank nodes</a>,
+    <p class="changed">Within a directed graph, nodes are <a>resources</a>, and may
+      be <em>unnamed</em>, i.e., not identified by an <a>IRI</a>;
+      which are called <a>blank nodes</a>,
       and may be identified using a <a>blank node identifier</a>.
       These identifiers may be required to represent a fully connected graph
       using a tree structure, such as JSON, but otherwise have no
-      intrinsic meaning.</p>
+      intrinsic meaning.
+      Literal values, such as <a>strings</a> and <a>numbers</a>, are also considered <a>resources</a>,
+      and JSON-LD distinguishes between <a>node objects</a> and <a>value objects</a> to distinguish between the different
+      kinds of <a>resource</a>.</p>
     <p>This simple data model is incredibly
       flexible and powerful, capable of modeling almost any kind of
       data. For a deeper explanation of the data model, see

--- a/index.html
+++ b/index.html
@@ -2140,6 +2140,16 @@
     The following example specifies an external context
     and then layers an <a>embedded context</a> on top of the external context:</p>
 
+  <p class="changed">In JSON-LD 1.1, there are other mechanisms for introducing contexts, including
+    scoped contexts and imported contexts, and there are new ways of protecting term definitions,
+    so there are cases where the last defined inline context is not necessarily one
+    which defines the scope of terms.
+    See <a href="#scoped-contexts" class="sectionRef"></a>,
+    <a href="#context-propagation" class="sectionRef"></a>,
+    <a href="#imported-contexts" class="sectionRef"></a>, and
+    <a href="#protected-term-definitions" class="sectionRef"></a>
+    for further information.</p>
+
   <aside class="example ds-selector-tabs"
          title="Combining external and local contexts">
     <div class="selectors">

--- a/index.html
+++ b/index.html
@@ -427,9 +427,9 @@
    <dt>Simplicity</dt>
    <dd>No extra processors or software libraries are necessary to use JSON-LD
      in its most basic form. The language provides developers with a very easy
-     learning curve. Developers only need to know JSON and two
-     <a>keywords</a> (<code>@context</code>
-     and <code>@id</code>) to use the basic functionality in JSON-LD.</dd>
+     learning curve. Developers not concerned with Linked Data only need to understand JSON,
+     and know to include but ignore the <code>@context</code> property,
+     to use the basic functionality in JSON-LD.</dd>
    <dt>Compatibility</dt>
    <dd>A JSON-LD document is always a valid JSON document. This ensures that
     all of the standard JSON libraries work seamlessly with JSON-LD documents.</dd>

--- a/index.html
+++ b/index.html
@@ -3440,90 +3440,91 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     types are listed, the order that <a>type-scoped contexts</a> are applied is based on
     lexicographical ordering.</p>
 
-  <p>For example, consider the following semantically equivalent examples:</p>
+  <p>For example, consider the following semantically equivalent examples.
+    The first example, shows how properties and types can define their own
+    scoped contexts, which are included when expanding.</p>
 
-  <aside class="example" title="Expansion using embedded and scoped contexts">
-    <p>This example, shows how properties and types can define their own
-      scoped contexts, which are included when expanding.</p>
-    <pre data-transform="updateExample">
-    <!--
-    {
-      "@context": {
-        "@vocab": "http://example.com/vocab/"
-        "property": {
-          "@id": "http://example.com/vocab/property",
-          "@context": {
-            "term1": "http://example.com/vocab/term1"
-            #### ↑ Scoped context for "property" defines term1
-          },
-        },
-        "Type1": {
-          "@id": "http://example.com/vocab/Type1",
-          "@context": {
-            "term3": "http://example.com/vocab/term3"
-            #### ↑ Scoped context for "Type1" defines term3
-          },
-        },
-        "Type2": {
-          "@id": "http://example.com/vocab/Type2",
-          "@context": {
-            "term4": "http://example.com/vocab/term4"
-            #### ↑ Scoped context for "Type2" defines term4
-          },
-        },
-      },
+  <pre class="example" title="Expansion using embedded and scoped contexts" data-transform="updateExample">
+  <!--
+  {
+    "@context": {
+      "@version": 1.1,
+      "@vocab": "http://example.com/vocab/",
       "property": {
+        "@id": "http://example.com/vocab/property",
         "@context": {
-          "term2": "http://example.com/vocab/term2"
-            #### ↑ Embedded context defines term2
-        },
-        "@type": ["Type2", "Type1"],
-        "term1": "a",
-        "term2": "b",
-        "term3": "c",
-        "term4": "d",
-      }
-    }
-    -->
-    </pre>
-
-    <p>Contexts are processed depending on how they are defined. A <a>property-scoped context</a>
-      is processed first, followed by any <a>embedded context</a>,
-      followed lastly by the <a>type-scoped contexts</a>, in the appropriate order.
-      The previous example is logically equivalent to the following:</p>
-    <pre data-transform="updateExample">
-    <!--
-    {
-      "@context": {
-        "@vocab": "http://example.com/vocab/"
-        "property": "http://example.com/vocab/property",
-        "Type1": "http://example.com/vocab/Type1",
-        "Type2": "http://example.com/vocab/Type2",
+          "term1": "http://example.com/vocab/term1"
+          #### ↑ Scoped context for "property" defines term1####
+        }
       },
-      "property": {
-        "@context": [{
-            "term1": "http://example.com/vocab/term1"
-            #### ↑ Scoped context for "property" defines term1
-          }, {
-            "term2": "http://example.com/vocab/term2"
-            #### ↑ Embedded context defines term2
-          }, {
-            "term3": "http://example.com/vocab/term3"
-            #### ↑ Scoped context for "Type1" defines term3
-          }, {
+      "Type1": {
+        "@id": "http://example.com/vocab/Type1",
+        "@context": {
+          "term3": "http://example.com/vocab/term3"
+          #### ↑ Scoped context for "Type1" defines term3####
+        }
+      },
+      "Type2": {
+        "@id": "http://example.com/vocab/Type2",
+        "@context": {
           "term4": "http://example.com/vocab/term4"
-            #### ↑ Scoped context for "Type2" defines term4
-        }],
-        "@type": ["Type2", "Type1"],
-        "term1": "a",
-        "term2": "b",
-        "term3": "c",
-        "term4": "d",
+          #### ↑ Scoped context for "Type2" defines term4####
+        }
       }
+    },
+    "property": {
+      "@context": {
+        "term2": "http://example.com/vocab/term2"
+          #### ↑ Embedded context defines term2####
+      },
+      "@type": ["Type2", "Type1"],
+      "term1": "a",
+      "term2": "b",
+      "term3": "c",
+      "term4": "d"
     }
-    -->
-    </pre>
-  </aside>
+  }
+  -->
+  </pre>
+
+  <p>Contexts are processed depending on how they are defined.
+    A <a>property-scoped context</a> is processed first,
+    followed by any <a>embedded context</a>,
+    followed lastly by the <a>type-scoped contexts</a>,
+    in the appropriate order. The previous example is logically equivalent to the following:</p>
+
+  <pre class="example" title="Expansion using embedded and scoped contexts (embedding equivalent)" data-transform="updateExample">
+  <!--
+  {
+    "@context": {
+      "@vocab": "http://example.com/vocab/",
+      "property": "http://example.com/vocab/property",
+      "Type1": "http://example.com/vocab/Type1",
+      "Type2": "http://example.com/vocab/Type2"
+    },
+    "property": {
+      "@context": [{
+          "term1": "http://example.com/vocab/term1"
+          #### ↑ Previously scoped context for "property" defines term1####
+        }, {
+          "term2": "http://example.com/vocab/term2"
+          #### ↑ Embedded context defines term2####
+        }, {
+          "term3": "http://example.com/vocab/term3"
+          #### ↑ Previously scoped context for "Type1" defines term3####
+        }, {
+        "term4": "http://example.com/vocab/term4"
+          #### ↑ Previously scoped context for "Type2" defines term4####
+      }],
+      "@type": ["Type2", "Type1"],
+      "term1": "a",
+      "term2": "b",
+      "term3": "c",
+      "term4": "d"
+    }
+  }
+  -->
+  </pre>
 
   <p class="note">If a <a>term</a> defines a <a>scoped context</a>,
     and then that term is later re-defined,

--- a/index.html
+++ b/index.html
@@ -4993,7 +4993,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <a>string</a> values that are not <a href="#type-coercion">type coerced</a>.</p>
 
   <p>To clear the <a>default language</a> for a subtree, <code>@language</code> can
-    be set to <code>null</code> in a <a>local context</a> as follows:</p>
+    be set to <code>null</code> in an intervening context, such as a <a>scoped context</a> as follows:</p>
 
   <pre class="example nohighlight" data-transform="updateExample"
        title="Clearing default language">
@@ -5001,15 +5001,15 @@ the data type to be specified explicitly with each piece of data.</p>
   {
     "@context": {
       ####...####
-      "@language": "ja"
+      "@language": "ja",
+      "details": {
+        ****"@context": {
+          "@language": null
+        }****
+      }
     },
     "name": "花澄",
-    "details": {
-      ****"@context": {
-        "@language": null
-      }****,
-      "occupation": "Ninja"
-    }
+    "details": {"occupation": "Ninja"}
   }
   -->
   </pre>

--- a/index.html
+++ b/index.html
@@ -329,8 +329,9 @@
   </ul>
 
   <p>JSON-LD is designed to be usable directly as JSON, with no knowledge of RDF
-   [[RDF11-CONCEPTS]]. It is also designed to be usable as RDF, if desired, for
-   use with other Linked Data technologies like SPARQL [[SPARQL11-OVERVIEW]]. Developers who
+   [[RDF11-CONCEPTS]]. It is also designed to be usable as RDF
+   in conjunction with other Linked Data technologies like SPARQL [[SPARQL11-OVERVIEW]].
+   Developers who
    require any of the facilities listed above or need to serialize an <a>RDF graph</a>
    or <a>Dataset</a> in a JSON-based syntax will find JSON-LD of interest. People
    intending to use JSON-LD with RDF tools will find it can be used as another

--- a/index.html
+++ b/index.html
@@ -596,6 +596,9 @@
         New features since [[[JSON-LD10]]] [[JSON-LD10]] described in this specification are
         only available when <a>processing mode</a> has been explicitly set to
         <code>json-ld-1.1</code>.
+        <div class="note">Within a <a>context definition</a> `@version` takes the specific value `1.1`, not
+        `"json-ld-1.1"`, as a JSON-LD 1.0 processor may accept a string value for `@version`,
+        but will reject a numeric value.</div>
       </dd>
       <dt class="changed"><code>@json</code></dt><dd class="changed">
         Used as the <code>@type</code> value of a <a>JSON literal</a>.

--- a/index.html
+++ b/index.html
@@ -467,14 +467,10 @@
   <section class="informative">
     <h2>Data Model Overview</h2>
 
-    <p>Generally speaking, the data model described by a
-      <a>JSON-LD document</a> is a labeled,
-      directed <a>graph</a>. The graph contains
-      <a>nodes</a>, which are connected by
-      directed-arcs. A <a>node</a> is typically data
-      such as a <a>string</a>, <a>number</a>,
-      <a>typed values</a> (like dates and times)
-      or an <a>IRI</a>.</p>
+    <p>Generally speaking, the data model described by a <a>JSON-LD document</a> is a labeled, directed <a>graph</a>.
+      The graph contains <a>nodes</a>, which are connected by directed-arcs.
+      A node is either a <a>resource</a> with <a>properties</a>, or the data values of those properties including
+      <a>strings</a>, <a>numbers</a>, <a>typed values</a> (like dates and times) and <a>IRIs</a>.</p>
     <p class="changed">Within a directed graph, nodes may
       be <em>unnamed</em>, i.e., not identified by an <a>IRI</a> or representing
       data such as <a>strings</a> or <a>numbers</a>. Such nodes are called <a>blank nodes</a>,

--- a/index.html
+++ b/index.html
@@ -2462,76 +2462,6 @@
     allows the value to be a <a>term</a> or <a>compact IRI</a>.
     Note that terms used in the value of `@vocab` must be in scope at the time the context is introduced,
     otherwise there would be a circular dependency between `@vocab` and other terms defined in the same context.</p>
-
-  <section id="document-relative-vocabulary-mapping" class="changed">
-    <h3>Using the Document Base for the Default Vocabulary</h3>
-    <p>In some cases, vocabulary terms are defined directly within the document
-      itself, rather than in an external vocabulary.
-      Since <code>json-ld-1.1</code>, the <a>vocabulary mapping</a> in a <a>local context</a>
-      can be set to a <a>relative IRI</a>,
-      which is, if there is no vocabulary mapping in scope, resolved against the <a>base IRI</a>.
-      This causes terms which are expanded relative to the vocabulary,
-      such as the keys of <a>node objects</a>,
-      to be based on the <a>base IRI</a> to create <a>absolute IRIs</a>.</p>
-
-  <pre class="example input nohighlight" data-transform="updateExample"
-       title="Using &quot;#&quot; as the vocabulary mapping"
-       data-base="http://example/document">
-  <!--
-    {
-      "@context": {
-        ****"@version": 1.1,****
-        ****"@base": "http://example/document",****
-        "@vocab": ****"#"****
-      },
-      "@id": "http://example.org/places#BrewEats",
-      "@type": ****"Restaurant"****,
-      ****"name"****: "Brew Eats"
-      ####...####
-    }
-  -->
-  </pre>
-
-  <p>If this document were located at <code>http://example/document</code>, it would expand as follows:</p>
-
-  <aside class="example ds-selector-tabs"
-         title="Using &quot;#&quot; as the vocabulary mapping (expanded)">
-    <div class="selectors">
-      <button class="selected" data-selects="expanded">Expanded (Result)</button>
-      <button data-selects="statements">Statements</button>
-      <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
-    </div>
-    <pre class="expanded result selected nohighlight" data-transform="updateExample">
-    <!--
-    [{
-      "@id": "http://example.org/places#BrewEats",
-      "@type": ["http://example/document#Restaurant"],
-      "http://example/document#name": [{"@value": "Brew Eats"}]
-    }]
-    -->
-    </pre>
-    <table class="statements"
-           data-result-for="Using &quot;#&quot; as the vocabulary mapping (expanded)-expanded"
-           data-to-rdf>
-      <thead><tr><th>Subject</th><th>Property</th><th>Value</th></tr></thead>
-      <tbody>
-        <tr><td>http://example.org/places#BrewEats</td><td>rdf:type</td><td>http://example/document#Restaurant</td></tr>
-        <tr><td>http://example.org/places#BrewEats</td><td>http://example/document#name</td><td>Brew Eats</td></tr>
-      </tbody>
-    </table>
-    <pre class="turtle"
-         data-content-type="text/turtle"
-         data-result-for="Using &quot;#&quot; as the vocabulary mapping (expanded)-expanded"
-         data-transform="updateExample"
-         data-to-rdf>
-    <!--
-    <http://example.org/places#BrewEats> a <http://example/document#Restaurant>;
-      <http://example/document#name> "Brew Eats" .
-    -->
-    </pre>
-  </aside>
-  </section>
 </section>
 
 <section class="informative"><h2>Base IRI</h2>
@@ -2622,6 +2552,76 @@
 
   <p>Please note that the <code>@base</code> will be ignored if used in
     external contexts.</p>
+</section>
+
+<section id="document-relative-vocabulary-mapping" class="changed">
+  <h3>Using the Document Base for the Default Vocabulary</h3>
+  <p>In some cases, vocabulary terms are defined directly within the document
+    itself, rather than in an external vocabulary.
+    Since <code>json-ld-1.1</code>, the <a>vocabulary mapping</a> in a <a>local context</a>
+    can be set to a <a>relative IRI</a>,
+    which is, if there is no vocabulary mapping in scope, resolved against the <a>base IRI</a>.
+    This causes terms which are expanded relative to the vocabulary,
+    such as the keys of <a>node objects</a>,
+    to be based on the <a>base IRI</a> to create <a>absolute IRIs</a>.</p>
+
+<pre class="example input nohighlight" data-transform="updateExample"
+     title="Using &quot;#&quot; as the vocabulary mapping"
+     data-base="http://example/document">
+<!--
+  {
+    "@context": {
+      ****"@version": 1.1,****
+      ****"@base": "http://example/document",****
+      "@vocab": ****"#"****
+    },
+    "@id": "http://example.org/places#BrewEats",
+    "@type": ****"Restaurant"****,
+    ****"name"****: "Brew Eats"
+    ####...####
+  }
+-->
+</pre>
+
+<p>If this document were located at <code>http://example/document</code>, it would expand as follows:</p>
+
+<aside class="example ds-selector-tabs"
+       title="Using &quot;#&quot; as the vocabulary mapping (expanded)">
+  <div class="selectors">
+    <button class="selected" data-selects="expanded">Expanded (Result)</button>
+    <button data-selects="statements">Statements</button>
+    <button data-selects="turtle">Turtle</button>
+    <a class="playground" target="_blank"></a>
+  </div>
+  <pre class="expanded result selected nohighlight" data-transform="updateExample">
+  <!--
+  [{
+    "@id": "http://example.org/places#BrewEats",
+    "@type": ["http://example/document#Restaurant"],
+    "http://example/document#name": [{"@value": "Brew Eats"}]
+  }]
+  -->
+  </pre>
+  <table class="statements"
+         data-result-for="Using &quot;#&quot; as the vocabulary mapping (expanded)-expanded"
+         data-to-rdf>
+    <thead><tr><th>Subject</th><th>Property</th><th>Value</th></tr></thead>
+    <tbody>
+      <tr><td>http://example.org/places#BrewEats</td><td>rdf:type</td><td>http://example/document#Restaurant</td></tr>
+      <tr><td>http://example.org/places#BrewEats</td><td>http://example/document#name</td><td>Brew Eats</td></tr>
+    </tbody>
+  </table>
+  <pre class="turtle"
+       data-content-type="text/turtle"
+       data-result-for="Using &quot;#&quot; as the vocabulary mapping (expanded)-expanded"
+       data-transform="updateExample"
+       data-to-rdf>
+  <!--
+  <http://example.org/places#BrewEats> a <http://example/document#Restaurant>;
+    <http://example/document#name> "Brew Eats" .
+  -->
+  </pre>
+</aside>
 </section>
 
 <section class="informative"><h2>Compact IRIs</h2>

--- a/index.html
+++ b/index.html
@@ -5080,7 +5080,10 @@ the data type to be specified explicitly with each piece of data.</p>
     example but consolidates all values in a single property. To access the
     value in a specific language in a programming language supporting dot-notation
     accessors for object properties, a developer may use the
-    <code>property.language</code> pattern. For example, to access the occupation
+    <code>property.language</code> pattern
+    (when languages are limited to the primary language sub-tag,
+    and do not depend on other sub-tags, such as `"en-us"`).
+    For example, to access the occupation
     in English, a developer would use the following code snippet:
     <code>obj.occupation.en</code>.</p>
 
@@ -7426,7 +7429,9 @@ the data type to be specified explicitly with each piece of data.</p>
     <strong>de</strong> keys are implicitly associated with their respective
     values by the <a>JSON-LD Processor</a>.  This allows a developer to
     access the German version of the <strong>label</strong> using the
-    following code snippet: <code>obj.label.de</code>.</p>
+    following code snippet: <code>obj.label.de</code>,
+    which, again, is only appropriate when languages are limited to the
+    primary language sub-tag and do not depend on other sub-tags, such as `"en-us"`.</p>
 
   <p>The value of <code>@container</code> can also
     be an array containing both <code>@language</code> and <code>@set</code>.

--- a/index.html
+++ b/index.html
@@ -3241,8 +3241,8 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     property, which defines a <a>context</a> (a <a>scoped context</a>) for
     <a data-lt="JSON-LD value">values</a> of properties defined using that <a>term</a>.
     When used for a <a>property</a>, this is called a <a>property-scoped context</a>.
-    This allows values to use <a>term definitions</a>, <a>base IRI</a>,
-    <a>vocabulary mapping</a> or <a>default language</a> which is different from the
+    This allows values to use <a>term definitions</a>, the <a>base IRI</a>,
+    <a>vocabulary mappings</a> or the <a>default language</a> which are different from the
     <a>node object</a> they are contained in, as if the
     <a>context</a> was specified within the value itself.</p>
 

--- a/index.html
+++ b/index.html
@@ -4919,11 +4919,7 @@ the data type to be specified explicitly with each piece of data.</p>
 <p class="note">Keys in the context are treated as <a>terms</a> for the purpose of
   expansion and value coercion. At times, this may result in multiple representations for the same expanded IRI.
   For example, one could specify that <code>dog</code> and <code>cat</code> both expanded to <code>http://example.com/vocab#animal</code>.
-  Doing this could be useful for establishing different type coercion or language specification rules. It also allows a <a>compact IRI</a> (or even an
-  absolute <a>IRI</a>) to be defined as something else entirely. For example, one could specify that
-  the <a>term</a> <code>http://example.org/zoo</code> should expand to
-  <code>http://example.org/river</code>, but this usage is discouraged because it would lead to a
-  great deal of confusion among developers attempting to understand the JSON-LD document.</p>
+  Doing this could be useful for establishing different type coercion or language specification rules.</p>
 </section>
 
 <section class="informative"><h2>String Internationalization</h2>

--- a/index.html
+++ b/index.html
@@ -2393,9 +2393,12 @@
 
   <p class="changed">Since <code>json-ld-1.1</code>,
     the <a>vocabulary mapping</a> in a <a>local context</a> can be set to the a <a>relative IRI</a>,
-      which is concatenated to any <a>vocabulary mapping</a> in the <a>active context</a>
-      (see <a href="#document-relative-vocabulary-mapping" class="sectionRef"></a>
-      for how this applies if there is no <a>vocabulary mapping</a> in the <a>active context</a>).</p>
+    which is concatenated to any <a>vocabulary mapping</a> in the <a>active context</a>
+    (see <a href="#document-relative-vocabulary-mapping" class="sectionRef"></a>
+    for how this applies if there is no <a>vocabulary mapping</a> in the <a>active context</a>).</p>
+
+  <p class="changed">The following example illustrates the affect of expanding a property using
+    a <a>relative IRI</a>, which is shown in the Expanded (Result) tab below.</p>
 
   <aside class="example ds-selector-tabs"
          title="Using a default vocabulary relative to a previous default vocabulary">

--- a/index.html
+++ b/index.html
@@ -584,8 +584,7 @@
         <a>IRI</a>. This keyword is described in <a class="sectionRef" href="#default-vocabulary"></a>.</dd>
       <dt><code>@graph</code></dt><dd>Used to express a <a>graph</a>.
         This keyword is described in <a class="sectionRef" href="#named-graphs"></a>.</dd>
-      <dt class="changed"><code>@nest</code></dt><dd class="changed">Collects a set of <a>nested properties</a> within
-        a <a>node object</a>.</dd>
+      <dt class="changed"><code>@nest</code></dt><dd class="changed">Used to define a <a>property</a> of a <a>node object</a> that groups together properties of that node, but is not an edge in the graph.</dd>
       <dt class="changed"><code>@none</code></dt><dd class="changed">Used as an index value
         in an <a>index map</a>, <a>id map</a>, <a>language map</a>, <a>type map</a>, or elsewhere where a <a>map</a> is
         used to index into other values.</dd>

--- a/index.html
+++ b/index.html
@@ -953,7 +953,9 @@
       <a>contexts</a> may also be specified inline.
       This has the advantage that documents can be processed even in the
       absence of a connection to the Web. Ultimately, this is a modeling decision
-      and different use cases may require different handling.</p>
+      and different use cases may require different handling.
+      See See <a href="#iana-security">Security Considerations</a> in <a href="#iana-considerations" class="sectionRef"></a>
+      for a discussion other considerations for using remote contexts.</p>
 
     <aside class="example ds-selector-tabs"
            title="In-line context definition">

--- a/index.html
+++ b/index.html
@@ -4331,9 +4331,15 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
   express the value of a type.</p>
 
 <p class="note">The <code>@type</code> <a>keyword</a> is also used to associate a type
-  with a <a>node</a>. The concept of a <a>node type</a> and
-  a <a>value type</a> are different.
+  with a <a>node</a>.
+  The concept of a <a>node type</a> and a <a>value type</a> are distinct.
   For more on adding types to <a>nodes</a>, see <a class="sectionRef" href="#specifying-the-type"></a>.</p>
+
+<p class="note">When expanding, an `@type` defined within a <a>term definition</a>
+  can be associated with a <a>string</a> value to create an expanded <a>value object</a>,
+  which is described in <a href="#type-coercion" class="sectionRef"></a>.
+  Type coercion only takes place on string values, not for values which are <a>maps</a>,
+  such as <a>node objects</a> and <a>value objects</a> in their expanded form.</p>
 
 <p>A <dfn>node type</dfn> specifies the type of thing
   that is being described, like a person, place, event, or web page. A

--- a/index.html
+++ b/index.html
@@ -1655,7 +1655,7 @@
     further discussion.</p></dd>
   <dt>Property nesting</dt>
   <dd><p>Another JSON idiom often found in APIs is to use an
-      intermediate object to represent the properties of an object; in JSON-LD
+      intermediate object to to group together related properties of an object; in JSON-LD
       these are referred to as <a>nested properties</a> and are described in <a
       href="#nested-properties" class="sectionRef"></a>.</p></dd>
   <dt>Referencing objects</dt>

--- a/index.html
+++ b/index.html
@@ -3662,8 +3662,8 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     additional type coercion information.</p>
 
   <p>The following examples illustrate how `@import` can be used to express
-    a for <a>type-scoped context</a> that loads an imported <a>context</a> and
-    sets `@propagate` to `true` and how to make similar modifications.</p>
+    a <a>type-scoped context</a> that loads an imported <a>context</a> and
+    sets `@propagate` to `true`, as a technique for making other similar modifications.</p>
 
   <p>Suppose there was a <a>context</a> that could be referenced remotely
     via the URL <code>https://json-ld.org/contexts/remote-context.jsonld</code>:</p>

--- a/index.html
+++ b/index.html
@@ -604,7 +604,7 @@
       <dt class="changed"><code>:</code></dt><dd class="changed">
         The separator for JSON keys and values that use <a>compact IRIs</a>.</dd>
       <dt class="changed">`@propagate`</dt><dd class="changed">
-        Used in a <a>context definition</a> to change the sccope of that context.
+        Used in a <a>context definition</a> to change the scope of that context.
         By default, it is `true`,
         meaning that contexts propagate across <a>node objects</a>
         (other than for <a>type-scoped contexts</a>, which default to `false`).

--- a/index.html
+++ b/index.html
@@ -807,10 +807,13 @@
     terms to communicate with one another more efficiently, but without
     losing accuracy.</p>
 
-    <p>Simply speaking, a <a>context</a> is used to map <a>terms</a> to
-      <a>IRIs</a>. <a>Terms</a> are case sensitive
-      and any valid <a>string</a> that is not a reserved JSON-LD <a>keyword</a>
-      can be used as a <a>term</a>.</p>
+    <p>Simply speaking, a <a>context</a> is used to map <a>terms</a> to <a>IRIs</a>.
+      <a>Terms</a> are case sensitive and most any valid <a>string</a> that is not a reserved JSON-LD <a>keyword</a>
+      can be used as a <a>term</a>.
+      <span class="changed">The empty string `""` and strings that have the form
+        of a keyword (e.g., staring with `"@"`) must not be used as terms.
+        Strings that have the form of
+        an absolute IRI (e.g., containing a `":"`) should not be used as terms.</span></p>
 
     <p>For the sample document in the previous section, a <a>context</a> would
       look something like this:</p>
@@ -11643,8 +11646,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <p>A <a>term</a> is a short-hand <a>string</a> that expands
       to an <a>IRI</a> or a <a>blank node identifier</a>.</p>
 
-    <p>A <a>term</a> MUST NOT equal any of the JSON-LD
-      <a>keywords</a>.</p>
+    <p>A <a>term</a> MUST NOT equal any of the JSON-LD <a>keywords</a>.</p>
 
     <p class="changed">When used as the <a>prefix</a> in a <a>Compact IRI</a>, to avoid
       the potential ambiguity of a <a>prefix</a> being confused with an IRI


### PR DESCRIPTION
* "This specification defines JSON-LD" => "This specification defines JSON-LD 1.1". Fixes #217. 
* Remove "if desired" Fixes #218.
* Improve _default language_ definition. Fixes #219.
* it's => its fixes. Fixes #221, fixes #223, and fixes #239.
* ore => or. Fixes #222. 
* Simplify simplicity. Fixes #224.
* Improve data model overview. For #225.
* Clarify that literals are not blank nodes. Fixes #226.
* Improve definition of `@nest`. Fixes #227.
* Update `@none` definition. Fixes #228.
* sccope => scope. Fixes #229.
* Clarify that `@version` is set to `1.1`, not `"json-ld-1.1"`. Fixes #230.
* Improve requirements of terms. Improve requirements of terms.
* Reference security considerations for remote contexts. Fixes #232.
* Update local dfns to not be links by removing data-cite. Fixes #233.
* Add a missing description of list objects and set objects. Fixes #234.
* Fix wording of nested properties. Fixes #235.
* Add forward references for other things that affect the context in section 4.1. Fixes #236.
* Better describe example 25. Fixes #237.
* Move subsection on using the document base for the default vocabulary until after the section on the document base (4.1.2.1 => 4.1.4). Fixes #238.
* Fix grammar in Scoped Contexts section. Fixes #240.
* Split example 46 into separate examples. Fixes #241.
* Re-defined => Redefined. Fixes #242.
* limits => limit. Fixes #243.
* Fix grammar in Imported Contexts section. Fixes #244.
* effect => affect. Fixes #245.
* Further clarify that type coercion takes place only on strings, not maps. Fixes #247.
* Make examples clearer. Fixes #248.
* Remove old warning in note about redefining IRIs to have a different meaning, which is now disallowed. Fixes #249.
* Use a scoped, rather than an embedded context for default language example. Fixes #250.
* Note that indexing of language tags depends on their not using sub-tags other than the primary language-tag. Fixes #251.
* Remove uninformative note on type coercion from 4.5. Fixes #252.
*


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/265.html" title="Last updated on Sep 24, 2019, 9:00 PM UTC (09dcd19)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/265/fecd5c4...09dcd19.html" title="Last updated on Sep 24, 2019, 9:00 PM UTC (09dcd19)">Diff</a>