### PR TITLE
added missing keywords in sections 1.7, 9.15 and 9.16, addressing #262

### DIFF
--- a/index.html
+++ b/index.html
@@ -614,6 +614,9 @@
         (other than for <a>type-scoped contexts</a>, which default to `false`).
         Setting this to `false` causes term definitions created within that context
         to be removed when entering a new <a>node object</a>.</dd>
+      <dt class="changed">`@protected`</dt><dd class="changed">
+        Used to prevent <a>term definitions</a> of a context to be overriden by other contexts.
+        This keyword is described in <a class="sectionRef" href="#protected-term-definitions"></a>.
       <dt class="changed">`@import`</dt><dd class="changed">
         Used in a <a>context definition</a> to load an external context
         within which the containing <a>context definition</a> is merged.
@@ -12151,27 +12154,46 @@ the data type to be specified explicitly with each piece of data.</p>
 
   <p>A <a>context definition</a> MUST be a <a>map</a> whose
     keys MUST be either <a>terms</a>, <a>compact IRIs</a>, <a>absolute IRIs</a>,
-    or one of the <a>keywords</a> <code>@language</code>, <code>@base</code>,
-    <code class="changed">@type</code>, <code>@vocab</code>, or <code class="changed">@version</code>.</p>
-
-  <p>If the <a>context definition</a> has an <code>@language</code> key,
-    its value MUST have the <a data-cite="BCP47#section-2.1.1">lexical form</a> described in [[BCP47]] or be <a>null</a>.</p>
+    or one of the <a>keywords</a>
+    <code>@base</code>,
+    <code class="changed">@import</code>,
+    <code>@language</code>,
+    <code class="changed">@propagate</code>,
+    <code class="changed">@protected</code>,
+    <code class="changed">@type</code>,
+    <code class="changed">@version</code>.
+    or <code>@vocab</code>.
+  </p>
 
   <p>If the <a>context definition</a> has an <code>@base</code> key,
     its value MUST be an <a>absolute IRI</a>, a <a>relative IRI</a>,
     or <a>null</a>.</p>
 
+  <p>If the <a>context definition</a> has an <code>@language</code> key,
+    its value MUST have the <a data-cite="BCP47#section-2.1.1">lexical form</a> described in [[BCP47]] or be <a>null</a>.</p>
+
+  <p class="changed">If a <a>context</a> contains the <code>@import</code>
+    <a>keyword</a>, its value MUST be an <a>absolute IRI</a> or <a>relative IRI</a>.
+    When used as a reference from an `@import`, the referenced <a>context definition</a> MUST NOT
+    include an `@import` key, itself.</p>
+
+  <p class="changed">If the <a>context definition</a> has an <code>@propagate</code> key,
+    its value MUST be <code>true</code> or <code>false</code>.</p>
+
+  <p class="changed">If the <a>context definition</a> has an <code>@protected</code> key,
+    its value MUST be <code>true</code> or <code>false</code>.</p>
+
   <p class="changed">If the <a>context definition</a> has an <code>@type</code> key,
     its value MUST be a <a>map</a> with the single <a>entry</a> <code>@container</code> set to <code>@set</code>.</p>
+
+  <p class="changed">If the <a>context definition</a> has an <code>@version</code> key,
+    its value MUST be a <a>number</a> with the value <code>1.1</code>.</p>
 
   <p>If the <a>context definition</a> has an <code>@vocab</code> key,
     its value MUST be a <a>absolute IRI</a>, a <a>compact IRI</a>,
     a <a>blank node identifier</a>,
     <span class="changed">a <a>relative IRI</a></span>,
     a <a>term</a>, or <a>null</a>.</p>
-
-  <p class="changed">If the <a>context definition</a> has an <code>@version</code> key,
-    its value MUST be a <a>number</a> with the value <code>1.1</code>.</p>
 
   <p>The value of keys that are not <a>keywords</a> MUST be either an
     <a>absolute IRI</a>, a <a>compact IRI</a>, a <a>term</a>,
@@ -12186,14 +12208,13 @@ the data type to be specified explicitly with each piece of data.</p>
   <p>An <a>expanded term definition</a> MUST be a <a>map</a>
     composed of zero or more keys from
     <code>@id</code>,
-    <code class="changed">@import</code>,
     <code>@reverse</code>,
     <code>@type</code>,
     <code>@language</code>,
     <code>@container</code>,
     <code class="changed">@context</code>,
-    <code class="changed">@prefix</code>, or
-    <code class="changed">@propagate</code>.
+    <code class="changed">@prefix</code>,
+    <code class="changed">@protected</code>.
     An <a>expanded term definition</a> SHOULD NOT contain any other keys.</p>
 
   <p>If the term being defined is not a <a>compact IRI</a> or
@@ -12260,13 +12281,8 @@ the data type to be specified explicitly with each piece of data.</p>
   <p class="changed">If the <a>expanded term definition</a> contains the <code>@prefix</code>
     <a>keyword</a>, its value MUST be <code>true</code> or <code>false</code>.</p>
 
-  <p class="changed">If the <a>expanded term definition</a> contains the <code>@propagate</code>
+  <p class="changed">If the <a>expanded term definition</a> contains the <code>@protected</code>
     <a>keyword</a>, its value MUST be <code>true</code> or <code>false</code>.</p>
-
-  <p class="changed">If a <a>context</a> contains the <code>@import</code>
-    <a>keyword</a>, its value MUST be an <a>absolute IRI</a> or <a>relative IRI</a>.
-    When used as a reference from an `@import`, the referenced <a>context definition</a> MUST NOT
-    include an `@import` key, itself.</p>
 
   <p><a>Terms</a> MUST NOT be used in a circular manner. That is,
     the definition of a term cannot depend on the definition of another term if that other
@@ -12400,6 +12416,12 @@ the data type to be specified explicitly with each piece of data.</p>
       The `@propagate` keyword MUST NOT be aliased, and MAY be used in a <a>context definition</a>.
       Its value MUST be <code>true</code> or <code>false</code>.
       See <a class="sectionRef" href="#context-propagation"></a> for a further discussion.
+    </dd>
+    <dt class="changed">`@protected`</dt><dd class="changed">
+      The `@protected` keyword MUST NOT be aliased, and MAY be used in a <a>context definition</a>,
+      or an <a>expanded term definition</a>.
+      Its value MUST be <code>true</code> or <code>false</code>.
+      See <a class="sectionRef" href="#protected-term-definitions"></a> for a further discussion.
     </dd>
     <dt><code>@reverse</code></dt><dd>
       The <code>@reverse</code> keyword MAY be aliased and MAY be used as a key in a <a>node object</a>.


### PR DESCRIPTION
also
- reordered the keywords (in alphabetical order)
  in the def of "context definition"
- removed spurious keywords in the def "expanded term definitions"
  (@import, @propagate)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/268.html" title="Last updated on Sep 25, 2019, 7:45 PM UTC (5b567e1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/268/dbfd7c4...5b567e1.html" title="Last updated on Sep 25, 2019, 7:45 PM UTC (5b567e1)">Diff</a>