### PR TITLE
Add note that `null` is preserved in JSON literals.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4544,6 +4544,11 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
   -->
   </pre>
 </aside>
+
+<p class="note">Generally, when a JSON-LD processor encounters `null`,
+  the associated <a>entry</a> or value is removed.
+  However, `null` is a valid JSON token; when used as the value
+  of a <a>JSON literal</a>, a `null` value will be preserved.</p>
 </section>
 
 <section class="informative"><h2>Type Coercion</h2>


### PR DESCRIPTION
Fixes #258.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/275.html" title="Last updated on Sep 30, 2019, 7:13 PM UTC (3af6a7f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/275/99288f7...3af6a7f.html" title="Last updated on Sep 30, 2019, 7:13 PM UTC (3af6a7f)">Diff</a>