### PR TITLE
Weaken requirement to normalize language tags

### DIFF
--- a/common/terms.html
+++ b/common/terms.html
@@ -114,7 +114,7 @@
     as defined by [[BCP47]].
     The <dfn data-cite="RDF11-CONCEPTS#dfn-language-tag">language tag</dfn> MUST be well-formed
     according to <a data-cite="BCP47#section-2.2.9">section 2.2.9 Classes of Conformance</a> of [[BCP47]],
-    and is normalized to lowercase.</dd>
+    <span class="changed">and MAY be normalized to lowercase</span>.</dd>
   <dt><dfn data-cite="LINKED-DATA" data-no-xref="" class="preserve">Linked Data</dfn></dt><dd>
     A set of documents, each containing a representation of a <a>linked data graph</a> or <a>dataset</a>.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-graph" data-lt="linked data graph|graph" class="preserve">RDF graph</dfn></dt><dd>


### PR DESCRIPTION
As mentioned by @gkellogg in https://github.com/w3c/json-ld-api/pull/164, this weakens the requirement for normalizing language tags to lowercase, and makes it a "MAY", just like the RDF spec does.