### PR TITLE
Lazy eval version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ruby-rdf/json-ld.git
-  revision: b1a47abbdd6db71d2b9ccb42811445fee1626d60
+  revision: 94a5f041320f71ef89e4e82c73a01fd07ab4af27
   branch: develop
   specs:
     json-ld (3.0.2)
@@ -74,7 +74,7 @@ GEM
       sparql (~> 3.0)
       sparql-client (~> 3.0)
     mini_portile2 (2.4.0)
-    multi_json (1.14.0)
+    multi_json (1.14.1)
     net-http-persistent (3.1.0)
       connection_pool (~> 2.2)
     nokogiri (1.10.4)

--- a/common/terms.html
+++ b/common/terms.html
@@ -320,13 +320,16 @@
     when prepended to the suffix of the <a>compact IRI</a>,
     results in an <a>absolute IRI</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-processing-mode">processing mode</dfn></dt><dd>
-    The processing mode defines how a <a>JSON-LD document</a> is processed.
-    By default, all documents are assumed to be conformant with <a data-cite="JSON-LD10" data-no-xref="">JSON-LD 1.0</a> [[JSON-LD10]].
+    The <a>processing mode</a> defines how a <a>JSON-LD document</a> is processed.
+    By default, all documents are assumed to be conformant with this specification.
     By defining a different version using the <code>@version</code> <a>entry</a> in a <a>context</a>,
-    or via explicit API option,
-    other processing modes can be accessed.
+    publishers can ensure that processors conformant with <a data-cite="JSON-LD10" data-no-xref="">JSON-LD 1.0</a> [[JSON-LD10]]
+    will not accidently process JSON-LD 1.1 documents, possibly creating a different output.
+    The API provides an option for setting the <a>processing mode</a> to `json-ld-1.0`,
+    which will prevent JSON-LD 1.1 features from being activated,
+    or error if <code>@version</code> <a>entry</a> in a <a>context</a> is explicitly set to `1.1`.
     This specification extends <a data-cite="JSON-LD10" data-no-xref="">JSON-LD 1.0</a>
-    via the <code>json-ld-1.1</code> <a>processing mode</a>.</dd>
+    via the `json-ld-1.1` <a>processing mode</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-set-object">set object</dfn></dt><dd>
     A <a>set object</a> is a <a>map</a> that has an <code>@set</code> <a>entry</a>.
     It may also have an <code>@index</code> key, but no other <a>entries</a>.</dd>

--- a/index.html
+++ b/index.html
@@ -601,8 +601,8 @@
       <dt class="changed"><code>@version</code></dt><dd class="changed">
         Used in a <a>context definition</a> to set the <a>processing mode</a>.
         New features since [[[JSON-LD10]]] [[JSON-LD10]] described in this specification are
-        only available when <a>processing mode</a> has been explicitly set to
-        <code>json-ld-1.1</code>.
+        not available when <a>processing mode</a> has been explicitly set to
+        `json-ld-1.0`.
         <div class="note">Within a <a>context definition</a> `@version` takes the specific value `1.1`, not
         `"json-ld-1.1"`, as a JSON-LD 1.0 processor may accept a string value for `@version`,
         but will reject a numeric value.</div>
@@ -2247,9 +2247,12 @@
 <section class="changed informative"><h2>JSON-LD 1.1 Processing Mode</h2>
 
   <p>New features defined in JSON-LD 1.1 are available
-    when the <a>processing mode</a> is set to <code>json-ld-1.1</code>.
-    This may be set using the <code>@version</code> <a>entry</a> in a <code>context</code>
-    set to the value <code>1.1</code> as a <a>number</a>, or through an API option.</p>
+    unless the <a>processing mode</a> is set to `json-ld-1.0`.
+    This may be set through an API option.
+    The <a>processing mode</a> may be explicitly set to `json-ld-1.1` using the `@version` <a>entry</a> in a <a>context</a>
+    set to the value `1.1` as a <a>number</a>, or through an API option.
+    Explicitly setting the <a>processing mode</a> to `json-ld-1.1`
+    will prohibit JSON-LD 1.0 processors from incorrectly processing a JSON-LD 1.1 document.</p>
 
   <pre class="example nohighlight" data-transform="updateExample"
        title="Setting @version in context">
@@ -2272,9 +2275,9 @@
     the former will be interpreted as having had <code>"@version": 1.1</code> defined within it.</p>
 
   <p class="note">Setting the <a>processing mode</a> explicitly
-    for JSON-LD 1.1 is necessary so that a [[[JSON-LD10]]] processor
-    does not attempt to process a JSON-LD 1.1 document and silently
-    produce different results.</p>
+    to `json-ld-1.1` is RECOMMENDED to prevent a [[[JSON-LD10]]] processor
+    from incorrectly processing a JSON-LD 1.1 document and
+    producin different results.</p>
 </section>
 
 <section class="informative"><h2>Default Vocabulary</h2>
@@ -2405,7 +2408,7 @@
 
   </aside>
 
-  <p class="changed">Since <code>json-ld-1.1</code>,
+  <p class="changed">Since JSON-LD 1.1,
     the <a>vocabulary mapping</a> in a <a>local context</a> can be set to the a <a>relative IRI</a>,
     which is concatenated to any <a>vocabulary mapping</a> in the <a>active context</a>
     (see <a href="#document-relative-vocabulary-mapping" class="sectionRef"></a>
@@ -2572,7 +2575,7 @@
   <h3>Using the Document Base for the Default Vocabulary</h3>
   <p>In some cases, vocabulary terms are defined directly within the document
     itself, rather than in an external vocabulary.
-    Since <code>json-ld-1.1</code>, the <a>vocabulary mapping</a> in a <a>local context</a>
+    Since JSON-LD 1.1, the <a>vocabulary mapping</a> in a <a>local context</a>
     can be set to a <a>relative IRI</a>,
     which is, if there is no vocabulary mapping in scope, resolved against the <a>base IRI</a>.
     This causes terms which are expanded relative to the vocabulary,
@@ -2804,7 +2807,7 @@
     </pre>
   </aside>
 
-  <p class="changed">When operating with the default <a>processing mode</a>
+  <p class="changed">When operating explicitly with the <a>processing mode</a>
     for [[[JSON-LD10]]] compatibility, terms may be chosen as <a>compact IRI</a> prefixes when
     compacting only if a <a>simple term definition</a> is used where the value ends with a
     URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character (e.g, <code>/</code>,
@@ -2834,7 +2837,7 @@
   -->
   </pre>
 
-  <p class="changed">Using the following context in the default 1.0 <a>processing mode</a>
+  <p class="changed">Using the following context in the 1.0 <a>processing mode</a>
     will now select the term <em>vocab</em> rather than
     <em>property</em>, even though the IRI associated with
     <em>property</em> captures more of the original IRI.</p>
@@ -2910,8 +2913,7 @@
   <p class="changed">In the original [[JSON-LD10]],
     the term selection algorithm would have selected <em>property</em>,
     creating the Compact IRI <em>property:One</em>.
-    If the <a>processing mode</a> is <code>json-ld-1.1</code>, the original behavior can be
-    made explicit using <code>@prefix</code>:</p>
+    The original behavior can be made explicit using <code>@prefix</code>:</p>
 
   <pre id="term-selection-context-1"
        class="example context"
@@ -3065,11 +3067,11 @@
   <p><span class="changed">Other than for <code>@type</code>,</span> properties of
     <a>expanded term definitions</a> where the term is a <a>keyword</a>
     result in an error.
-    <span class="changed">When processing mode is set to <code>json-ld-1.1</code>,
+    <span class="changed">Unless the <a>processing mode</a> is set to `json-ld-1.0`,
       there is also an exception for <code>@type</code>;
       see <a href="#using-set-with-type" class="sectionRef"></a> for further details.</span></p>
 
-  <p class="changed">When processing mode is set to <code>json-ld-1.1</code>,
+  <p class="changed">Unless the <a>processing mode</a> is set to `json-ld-1.0`,
     aliases of <a>keywords</a> are either <a>simple term definitions</a>,
     where the value is a <a>keyword</a>,
     or a <a>expanded term definitions</a> with an `@id` <a>entry</a> and optionally an `@protected` <a>entry</a>;
@@ -3561,8 +3563,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     earlier less deeply nested definitions, as discussed in
     <a href="#advanced-context-usage" class="sectionRef"></a>.</p>
 
-  <p class="note"><a>Scoped Contexts</a> are a new feature in JSON-LD 1.1, requiring
-    <a>processing mode</a> set to <code>json-ld-1.1</code>.</p>
+  <p class="note"><a>Scoped Contexts</a> are a new feature in JSON-LD 1.1.</p>
 </section>
 
 <section class="informative changed"><h2>Context Propagation</h2>
@@ -4193,8 +4194,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     As a consequence, context publishers should use this feature with care.
     </p>
 
-  <p class="note">Protected term definitions are a new feature in JSON-LD 1.1, requiring
-    <a>processing mode</a> set to <code>json-ld-1.1</code>.</p>
+  <p class="note">Protected term definitions are a new feature in JSON-LD 1.1.</p>
 </section>
 </section>
 
@@ -6184,7 +6184,7 @@ the data type to be specified explicitly with each piece of data.</p>
 </section>
 
 <section class="informative changed"><h2>Using <code>@set</code> with <code>@type</code></h2>
-  <p class="changed">When <a>processing mode</a> is set to <code>json-ld-1.1</code>,
+  <p class="changed">Unless the <a>processing mode</a> is set to `json-ld-1.0`,
     <code>@type</code> may be used with an <a>expanded term definition</a> with <code>@container</code> set
     to <code>@set</code>; no other <a>entries</a> may be set within such an <a>expanded term definition</a>.
     This is used by the <a data-cite="JSON-LD11-API#compaction-algorithm">Compaction algorithm</a> to ensure that the values of <code>@type</code> (or an alias)
@@ -6517,8 +6517,7 @@ the data type to be specified explicitly with each piece of data.</p>
     </pre>
   </aside>
 
-  <p class="note"><a>Nested properties</a> are a new feature in JSON-LD 1.1, requiring
-    <a>processing mode</a> set to <code>json-ld-1.1</code>.</p>
+  <p class="note"><a>Nested properties</a> are a new feature in JSON-LD 1.1.</p>
 </section>
 
 <section class="informative"><h2>Embedding</h2>
@@ -7152,7 +7151,7 @@ the data type to be specified explicitly with each piece of data.</p>
     When <em>compacting</em>, this ensures that a <a>JSON-LD Processor</a> will use
     the <a>array</a> form for all values of indexes.</p>
 
-  <p class="changed">If the <a>processing mode</a> is set to <code>json-ld-1.1</code>,
+  <p class="changed">Unless the <a>processing mode</a> is set to `json-ld-1.0`,
     the special index <code>@none</code> is used for indexing
     data which does not have an associated index, which is useful to maintain
     a normalized representation.</p>
@@ -7290,7 +7289,7 @@ the data type to be specified explicitly with each piece of data.</p>
       the keys used to index objects are semantically linked to these objects,
       and should be preserved not only syntactically, but also semantically.
     </p>
-    <p>If the <a>processing mode</a> is set to <code>json-ld-1.1</code>,
+    <p>Unless the <a>processing mode</a> is set to `json-ld-1.0`,
       <code>"@container": "@index"</code> in a term description can be accompanied with
       an <code>"@index"</code> key. The value of that key must map to an <a>IRI</a>,
       which identifies the semantic property linking each object to its key.
@@ -7574,7 +7573,7 @@ the data type to be specified explicitly with each piece of data.</p>
     </pre>
   </aside>
 
-  <p class="changed">If the <a>processing mode</a> is set to <code>json-ld-1.1</code>,
+  <p class="changed">Unless the <a>processing mode</a> is set to `json-ld-1.0`,
     the special index <code>@none</code> is used for indexing
     strings which do not have a language; this is useful to maintain
     a normalized representation for string values not having a datatype.</p>
@@ -8010,8 +8009,7 @@ the data type to be specified explicitly with each piece of data.</p>
     </pre>
   </aside>
 
-  <p class="note"><a>Id maps</a> are a new feature in JSON-LD 1.1, requiring
-    <a>processing mode</a> set to <code>json-ld-1.1</code>.</p>
+  <p class="note"><a>Id maps</a> are a new feature in JSON-LD 1.1.</p>
 </section>
 <section class="informative changed"><h2>Node Type Indexing</h2>
 
@@ -8339,8 +8337,7 @@ the data type to be specified explicitly with each piece of data.</p>
   <p>As with <a>id maps</a>, when used with <code>@type</code>, a container may also
     include <code>@set</code> to ensure that key values are always contained in an array.</p>
 
-  <p class="note"><a>Type maps</a> are a new feature in JSON-LD 1.1, requiring
-    <a>processing mode</a> set to <code>json-ld-1.1</code>.</p>
+  <p class="note"><a>Type maps</a> are a new feature in JSON-LD 1.1.</p>
 </section>
 </section>
 
@@ -9317,8 +9314,7 @@ the data type to be specified explicitly with each piece of data.</p>
       associated with the <a>named graph</a>, which exists separately within
       the <a>dataset</a>.</p>
 
-    <p class="note">Graph Containers are a new feature in JSON-LD 1.1, requiring
-      <a>processing mode</a> set to <code>json-ld-1.1</code>.</p>
+    <p class="note">Graph Containers are a new feature in JSON-LD 1.1.</p>
   </section>
 
 <section class="informative changed"><h3>Named Graph Data Indexing</h3>
@@ -9575,8 +9571,7 @@ the data type to be specified explicitly with each piece of data.</p>
     -->
     </pre>
   </aside>
-  <p class="note">Named Graph Data Indexing is a new feature in JSON-LD 1.1, requiring
-    <a>processing mode</a> set to <code>json-ld-1.1</code>.</p>
+  <p class="note">Named Graph Data Indexing is a new feature in JSON-LD 1.1.</p>
 </section>
 
 <section class="informative changed"><h3>Named Graph Indexing</h3>
@@ -9859,8 +9854,7 @@ the data type to be specified explicitly with each piece of data.</p>
     </pre>
   </aside>
 
-  <p class="note">Graph Containers are a new feature in JSON-LD 1.1, requiring
-    <a>processing mode</a> set to <code>json-ld-1.1</code>.</p>
+  <p class="note">Graph Containers are a new feature in JSON-LD 1.1.</p>
 </section>
 </section>
 
@@ -13617,6 +13611,10 @@ the data type to be specified explicitly with each piece of data.</p>
       retrieving a JSON-LD document when the returned document is not JSON.</li>
     <li><a>Value objects</a>, and associated <a>context</a> and <a>term definitions</a> have been updated to 
       support `@direction` for setting the <a>base direction</a> of strings.</li>
+    <li>The <a>processing mode</a> is now implicitly `json-ld-1.1`, unless set
+      explicitly to `json-ld-1.0`. Processing mode is wired to `json-ld-1.1`
+      when the first JSON-LD 1.1 specific feature is encountered, and it is
+      not set explicilty.</li>
   </ul>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -13612,9 +13612,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <li><a>Value objects</a>, and associated <a>context</a> and <a>term definitions</a> have been updated to 
       support `@direction` for setting the <a>base direction</a> of strings.</li>
     <li>The <a>processing mode</a> is now implicitly `json-ld-1.1`, unless set
-      explicitly to `json-ld-1.0`. Processing mode is wired to `json-ld-1.1`
-      when the first JSON-LD 1.1 specific feature is encountered, and it is
-      not set explicitly.</li>
+      explicitly to `json-ld-1.0`.</li>
   </ul>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -2277,7 +2277,7 @@
   <p class="note">Setting the <a>processing mode</a> explicitly
     to `json-ld-1.1` is RECOMMENDED to prevent a [[[JSON-LD10]]] processor
     from incorrectly processing a JSON-LD 1.1 document and
-    producin different results.</p>
+    producing different results.</p>
 </section>
 
 <section class="informative"><h2>Default Vocabulary</h2>
@@ -13614,7 +13614,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <li>The <a>processing mode</a> is now implicitly `json-ld-1.1`, unless set
       explicitly to `json-ld-1.0`. Processing mode is wired to `json-ld-1.1`
       when the first JSON-LD 1.1 specific feature is encountered, and it is
-      not set explicilty.</li>
+      not set explicitly.</li>
   </ul>
 </section>
 


### PR DESCRIPTION
Describe implicit behavior as being for JSON-LD 1.1, with overrides available if `processingMode` set explicitly to `json-ld-1.0`.

For w3c/json-ld-api#161.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/284.html" title="Last updated on Oct 18, 2019, 8:49 PM UTC (804ae28)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/284/51f5007...804ae28.html" title="Last updated on Oct 18, 2019, 8:49 PM UTC (804ae28)">Diff</a>