### PR TITLE
Fix links

### DIFF
--- a/common/common.js
+++ b/common/common.js
@@ -36,11 +36,18 @@ function restrictReferences(utils, content) {
 require(["core/pubsubhub"], (respecEvents) => {
   "use strict";
 
-// remote data-cite on where the citation is to ourselves.
   respecEvents.sub('end', (message) => {
+    // remove data-cite on where the citation is to ourselves.
     const selfDfns = document.querySelectorAll("dfn[data-cite^='" + respecConfig.shortName.toUpperCase() + "']");
     for (const dfn of selfDfns) {
       delete dfn.dataset.cite;
+    }
+
+    // Update data-cite references to ourselves.
+    const selfRefs = document.querySelectorAll("a[data-cite^='" + respecConfig.shortName.toUpperCase() + "']");
+    for (const anchor of selfRefs) {
+      anchor.href= anchor.dataset.cite.replace(/^.*#/,"#");
+      delete anchor.dataset.cite;
     }
   });
 

--- a/common/terms.html
+++ b/common/terms.html
@@ -174,7 +174,7 @@
     whose value MUST be a <a>string</a> representing a [[BCP47]] language code or <code>null</code>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-default-object">default object</dfn></dt><dd>
     A <a>default object</a> is a <a>map</a> that has a <code>@default</code> key.</dd>
-  <dt><dfn data-cite="JSON-LD11#dfn-base-direction" data-lt="default base direction">base direction</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11#dfn-base-direction" data-lt="base direction|default base direction" data-lt-noDefault>base direction</dfn></dt><dd>
     The <a>base direction</a> is the direction used when a string does not have a direction associated with it directly.
     It can be set in the <a>context</a> using the <code>@direction</code> key
     whose value MUST be one of the strings `"ltr"`, `"rtl"`, or <code>null</code>.</dd>

--- a/common/terms.html
+++ b/common/terms.html
@@ -341,7 +341,7 @@
     where the key defines a <a>term</a>
     which may be used within a <a>map</a>
     as a key, type, or elsewhere that a string is interpreted as a vocabulary item.
-    Its value is either a string (<dfn data-cite="JSON-LD11#dfn-simple-term-definition" data-lt="simple term">simple term definition</dfn>),
+    Its value is either a string (<dfn data-cite="JSON-LD11#dfn-simple-term-definition" data-lt="simple term definition|simple term" data-lt-noDefault>simple term definition</dfn>),
     expanding to an <a>IRI</a>,
     or a map (<a>expanded term definition</a>).
   </dd>

--- a/index.html
+++ b/index.html
@@ -959,7 +959,7 @@
       is ignored when the document is used as an external <dfn data-lt="context document">JSON-LD context document</dfn>.</p>
 
     <p>JSON documents can be interpreted as JSON-LD without having to be modified by
-      referencing a <a>context</a> via an <a data-cite="RFC8288#section-3">HTTP Link Header</a>
+      referencing a <a>context</a> via an <a data-cite="RFC8288#header">HTTP Link Header</a>
       as described in <a class="sectionRef" href="#interpreting-json-as-json-ld"></a>. It is also
       possible to apply a custom context using the JSON-LD 1.1 API [[JSON-LD11-API]].</p>
 
@@ -10914,7 +10914,7 @@ the data type to be specified explicitly with each piece of data.</p>
 
 <section class="normative"><h2>Modifying Behavior with Link Relationships</h2>
   <p>Certain aspects of JSON-LD processing can be modified using
-    <dfn data-cite="RFC8288#section-3" data-no-xref>HTTP Link Headers</dfn> [[RFC8288]].
+    <dfn data-cite="RFC8288#header" data-no-xref>HTTP Link Headers</dfn> [[RFC8288]].
     These can be used when retrieving resources that are not, themselves, JSON-LD,
     but can be interpreted as JSON-LD by using information in a
     <a href="https://en.wikipedia.org/wiki/Link_relation" data-no-xref>Link Relation</a>.</p>
@@ -10946,7 +10946,7 @@ the data type to be specified explicitly with each piece of data.</p>
   <p>In order to use an external context with an ordinary JSON document,
     when retrieving an ordinary JSON document via HTTP, processors MUST
     attempt to retrieve any <a>JSON-LD document</a> referenced by a
-    <a data-cite="RFC8288#section-3">Link Header</a> with:</p>
+    <a data-cite="RFC8288#header">Link Header</a> with:</p>
 
   <ul>
     <li><code>rel="http://www.w3.org/ns/json-ld#context"</code>, and</li>
@@ -11003,7 +11003,7 @@ the data type to be specified explicitly with each piece of data.</p>
     served with the <code>application/ld+json</code>
     media type MUST have all context information, including references to external
     contexts, within the body of the document. Contexts linked via a
-    <code>http://www.w3.org/ns/json-ld#context</code> <a data-cite="RFC8288#section-3">HTTP Link Header</a> MUST be
+    <code>http://www.w3.org/ns/json-ld#context</code> <a data-cite="RFC8288#header">HTTP Link Header</a> MUST be
     ignored for such documents.</p>
 </section>
 
@@ -11016,7 +11016,7 @@ the data type to be specified explicitly with each piece of data.</p>
 
   <p>To specify an alternate location, a non-JSON resource
     (i.e., one using a media type other than `application/json` or a derivative)
-    can return the alternate location using a <a data-cite="RFC8288#section-3">Link Header</a> with:</p>
+    can return the alternate location using a <a data-cite="RFC8288#header">Link Header</a> with:</p>
 
   <ul>
     <li><code>rel="alternate"</code>, and</li>
@@ -11067,7 +11067,7 @@ the data type to be specified explicitly with each piece of data.</p>
 <section class="changed"><h2>Embedding JSON-LD in HTML Documents</h2>
 
   <p class="note">This section describes features available
-    with a <a>documentLoader</a> supporting <a data-cite="JSON-LD11-API#html-script-extraction">HTML script extraction</a>.
+    with a <a>documentLoader</a> supporting <a data-cite="JSON-LD11-API#extract-script-content">HTML script extraction</a>.
     See <a data-cite="JSON-LD11-API#remote-document-and-context-retrieval">Remote Document and Context Retrieval</a>
     for more information.</p>
 
@@ -11315,7 +11315,7 @@ the data type to be specified explicitly with each piece of data.</p>
       the content will remain escaped after processing through the
       JSON-LD API [[JSON-LD11-API]].
       <ul>
-        <li><code>&amp;amp;</code>  → &amp; (<a href="/wiki/Ampersand" title="Ampersand">ampersand</a>, U+0026)</li>
+        <li><code>&amp;amp;</code>  → &amp; (<a href="https://en.wikipedia.org/wiki/Ampersand" title="Ampersand">ampersand</a>, U+0026)</li>
         <li><code>&amp;lt;</code>   → &lt; (less-than sign, U+003C)</li>
         <li><code>&amp;gt;</code>   → &gt; (greater-than sign, U+003E)</li>
         <li><code>&amp;quot;</code> → " (quotation mark, U+0022)</li>
@@ -11521,7 +11521,7 @@ the data type to be specified explicitly with each piece of data.</p>
       as a <a>typed value</a> with type <code>xsd:string</code>), a <a>number</a>
       (<a>numbers</a> with a non-zero fractional part, i.e., the result of a modulo&#8209;1 operation,
       <span class="changed">or which are too large to represent as integers
-        (see <a data-cite="JSON-LD11-API#data-gound-tripping">Data Round Tripping</a>) in [[JSON-LD11-API]]),</span>
+        (see <a data-cite="JSON-LD11-API#data-round-tripping">Data Round Tripping</a>) in [[JSON-LD11-API]]),</span>
       are interpreted as <a>typed values</a> with type <code>xsd:double</code>, all other
       <a>numbers</a> are interpreted as <a>typed values</a>
       with type <code>xsd:integer</code>), <code>true</code> or <code>false</code> (which are interpreted as
@@ -13380,7 +13380,7 @@ the data type to be specified explicitly with each piece of data.</p>
             URIs with their own defined semantics.</p>
           <p>
             When used as a <a data-cite="RFC4288#section-4.3">media type parameter</a> [[RFC4288]]
-            in an <a data-cite="rfc7231#section-5.3.2">HTTP Accept header</a> [[RFC7231]],
+            in an <a data-cite="rfc7231#rfc.section.5.3.2">HTTP Accept header</a> [[RFC7231]],
             the value of the <code>profile</code> parameter MUST be enclosed in quotes (<code>"</code>) if it contains
             special characters such as whitespace, which is required when multiple profile URIs are combined.</p>
           <p>When processing the "profile" media type parameter, it is important to


### PR DESCRIPTION
* Replace anchors with data-cite to self with local hrefs (works around ReSpec issue).
* Fix "base direction" definition.
* Fix some links to RFCs which seem to have changed.

For w3c/json-ld-api#196.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Nov 4, 2019, 10:55 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fjson-ld-syntax%2F90b3bd1f2fa4335bffaddeece03bcaf7f9bf0b5f%2Findex.html%3FisPreview%3Dtrue)

```
[33m📡 HTTP Error 520:[39m [36mhttps://rawcdn.githack.com/w3c/json-ld-syntax/90b3bd1f2fa4335bffaddeece03bcaf7f9bf0b5f/index.html[39m
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/json-ld-syntax%23290.)._
</details>
