### PR TITLE
Add additional wording to the IANA considerations

### DIFF
--- a/index.html
+++ b/index.html
@@ -13399,8 +13399,13 @@ the data type to be specified explicitly with each piece of data.</p>
           </dl>
           <p>All other URIs starting with <code>http://www.w3.org/ns/json-ld</code>
             are reserved for future use by JSON-LD specifications.</p>
-          <p class="note">Other specifications may publish additional profile parameter
-            URIs with their own defined semantics.</p>
+          <p>Other specifications MAY create further structured subtypes
+            by using `+ld+json` as a suffix for a new base subtype.
+            Unless defined otherwise, such subtypes use the same
+            fragment identifier behavior as `application/ld+json`.</p>
+          <p>Other specifications may publish additional `profile` parameter
+            URIs with their own defined semantics.
+            This includes the ability to associated a file extension with a `profile` parameter.</p>
           <p>
             When used as a <a data-cite="RFC4288#section-4.3">media type parameter</a> [[RFC4288]]
             in an <a data-cite="rfc7231#rfc.section.5.3.2">HTTP Accept header</a> [[RFC7231]],
@@ -13636,6 +13641,8 @@ the data type to be specified explicitly with each piece of data.</p>
     <li>The <a>processing mode</a> is now implicitly `json-ld-1.1`, unless set
       explicitly to `json-ld-1.0`.</li>
     <li>Improve notation using <a>IRI</a>, <a>IRI reference</a>, and <a>relative IRI reference</a>.</li>
+    <li>Allow further structured subtypes of `application/ld+json` by using
+      `+ld+json` as a suffix for a new base type.</li>
   </ul>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -13400,12 +13400,13 @@ the data type to be specified explicitly with each piece of data.</p>
           <p>All other URIs starting with <code>http://www.w3.org/ns/json-ld</code>
             are reserved for future use by JSON-LD specifications.</p>
           <p>Other specifications MAY create further structured subtypes
-            by using `+ld+json` as a suffix for a new base subtype.
+            by using `+ld+json` as a suffix for a new base subtype, as in
+            `application/example+ld+json`.
             Unless defined otherwise, such subtypes use the same
             fragment identifier behavior as `application/ld+json`.</p>
           <p>Other specifications may publish additional `profile` parameter
             URIs with their own defined semantics.
-            This includes the ability to associated a file extension with a `profile` parameter.</p>
+            This includes the ability to associate a file extension with a `profile` parameter.</p>
           <p>
             When used as a <a data-cite="RFC4288#section-4.3">media type parameter</a> [[RFC4288]]
             in an <a data-cite="rfc7231#rfc.section.5.3.2">HTTP Accept header</a> [[RFC7231]],


### PR DESCRIPTION
to allow `+ld+json`… to be used as a structured subtype for new base types.

Allow file extensions to be associated with profile parameters to `application/ld+json`.

For #287.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/291.html" title="Last updated on Nov 6, 2019, 5:50 PM UTC (1b5048a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/291/ee9e486...1b5048a.html" title="Last updated on Nov 6, 2019, 5:50 PM UTC (1b5048a)">Diff</a>