### PR TITLE
Describe forward-compatibility issues with terms starting with `@`

### DIFF
--- a/index.html
+++ b/index.html
@@ -848,7 +848,7 @@
       <a>Terms</a> are case sensitive and most valid <a>strings</a> that are not reserved JSON-LD <a>keywords</a>
       can be used as a <a>term</a>.
       <span class="changed">Exceptions are the empty string `""` and strings that have the form
-        of a keyword (i.e., staring with `"@"`), which must not be used as terms.
+        of a keyword (i.e., staring with `"@"` followed by one or more <em>ALPHA</em> characters (see [[RFC5234]])), which must not be used as terms.
         Strings that have the form of
         an <a>IRI</a> (e.g., containing a `":"`) should not be used as terms.</span></p>
 
@@ -2258,7 +2258,9 @@
     <a>context</a> at the top are still conformant JSON-LD.</p>
 
   <p class="note">To avoid forward-compatibility issues, <a>terms</a>
-    starting with an&nbsp;<code>@</code> character are to be avoided as they
+    starting with an&nbsp;<code>@</code> character
+    <span class="changed">followed by one or more <em>ALPHA</em> characters (see [[RFC5234]])</span>
+    are to be avoided as they
     might be used as <a>keyword</a> in future versions
     of JSON-LD. Terms starting with an&nbsp;<code>@</code> character that are not
     <a data-lt="keyword">JSON-LD 1.1 keywords</a> are treated as any other term, i.e.,
@@ -11777,7 +11779,9 @@ the data type to be specified explicitly with each piece of data.</p>
       as defined in [[RFC3987]].</p>
 
     <p>To avoid forward-compatibility issues, a <a>term</a> SHOULD NOT start
-      with an <code>@</code> character as future versions of JSON-LD may introduce
+      with an <code>@</code> character
+      <span class="changed">followed by one or more <em>ALPHA</em> characters (see [[RFC5234]])</span>
+      as future versions of JSON-LD may introduce
       additional <a>keywords</a>. Furthermore, the term MUST NOT
       be an empty <a>string</a> (<code>""</code>) as not all programming languages
       are able to handle empty JSON keys.</p>
@@ -13644,6 +13648,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <li>Improve notation using <a>IRI</a>, <a>IRI reference</a>, and <a>relative IRI reference</a>.</li>
     <li>Allow further structured subtypes of `application/ld+json` by using
       `+ld+json` as a suffix for a new base type.</li>
+    <li>Warn about forward-compatibility issues for terms of the form (`"@"1*ALPHA`).</li>
   </ul>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -848,7 +848,7 @@
       <a>Terms</a> are case sensitive and most valid <a>strings</a> that are not reserved JSON-LD <a>keywords</a>
       can be used as a <a>term</a>.
       <span class="changed">Exceptions are the empty string `""` and strings that have the form
-        of a keyword (i.e., starting with `"@"` followed by one or more <em>ALPHA</em> characters (see [[RFC5234]])), which must not be used as terms.
+        of a keyword (i.e., starting with `"@"` followed exclusively by one or more <em>ALPHA</em> characters (see [[RFC5234]])), which must not be used as terms.
         Strings that have the form of
         an <a>IRI</a> (e.g., containing a `":"`) should not be used as terms.</span></p>
 
@@ -2259,7 +2259,7 @@
 
   <p class="note">To avoid forward-compatibility issues, <a>terms</a>
     starting with an&nbsp;<code>@</code> character
-    <span class="changed">followed by one or more <em>ALPHA</em> characters (see [[RFC5234]])</span>
+    <span class="changed">followed exclusively by one or more <em>ALPHA</em> characters (see [[RFC5234]])</span>
     are to be avoided as they
     might be used as <a>keyword</a> in future versions
     of JSON-LD. Terms starting with an&nbsp;<code>@</code> character that are not
@@ -11780,7 +11780,7 @@ the data type to be specified explicitly with each piece of data.</p>
 
     <p>To avoid forward-compatibility issues, a <a>term</a> SHOULD NOT start
       with an <code>@</code> character
-      <span class="changed">followed by one or more <em>ALPHA</em> characters (see [[RFC5234]])</span>
+      <span class="changed">followed exclusively by one or more <em>ALPHA</em> characters (see [[RFC5234]])</span>
       as future versions of JSON-LD may introduce
       additional <a>keywords</a>. Furthermore, the term MUST NOT
       be an empty <a>string</a> (<code>""</code>) as not all programming languages

--- a/index.html
+++ b/index.html
@@ -848,7 +848,7 @@
       <a>Terms</a> are case sensitive and most valid <a>strings</a> that are not reserved JSON-LD <a>keywords</a>
       can be used as a <a>term</a>.
       <span class="changed">Exceptions are the empty string `""` and strings that have the form
-        of a keyword (i.e., staring with `"@"` followed by one or more <em>ALPHA</em> characters (see [[RFC5234]])), which must not be used as terms.
+        of a keyword (i.e., starting with `"@"` followed by one or more <em>ALPHA</em> characters (see [[RFC5234]])), which must not be used as terms.
         Strings that have the form of
         an <a>IRI</a> (e.g., containing a `":"`) should not be used as terms.</span></p>
 


### PR DESCRIPTION
followed by one or more ALPHA characters.

For w3c/json-ld-api#191.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/293.html" title="Last updated on Nov 11, 2019, 7:22 PM UTC (efc725c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/293/411f708...efc725c.html" title="Last updated on Nov 11, 2019, 7:22 PM UTC (efc725c)">Diff</a>