### PR TITLE
Clean informative sections

### DIFF
--- a/common/terms.html
+++ b/common/terms.html
@@ -167,17 +167,23 @@
     for each IRI contained within a common vocabulary identified by <a>prefix</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-context">context</dfn></dt><dd>
     A set of rules for interpreting a <a>JSON-LD document</a>
-    as specified in the <a data-cite="JSON-LD11#the-context">The Context</a> section of JSON-LD 1.1.</dd>
+    as described in the <a data-cite="JSON-LD11#the-context">The Context</a> section of JSON-LD 1.1,
+    and normatively specified in the <a data-cite="JSON-LD11#context-definitions">Context Definitions</a> section of JSON-LD 1.1.
+  </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-default-language">default language</dfn></dt><dd>
     The <a>default language</a> is the language used when a string does not have a language associated with it directly.
     It can be set in the <a>context</a> using the <code>@language</code> key
-    whose value must be a <a>string</a> representing a [[BCP47]] language code or <code>null</code>.</dd>
+    whose value must be a <a>string</a> representing a [[BCP47]] language code or <code>null</code>.
+    See the <a data-cite="JSON-LD11#context-definitions">Context Definitions</a> section of JSON-LD 1.1 for a normative description.
+  </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-default-object">default object</dfn></dt><dd>
     A <a>default object</a> is a <a>map</a> that has a <code>@default</code> key.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-base-direction" data-lt="base direction|default base direction" data-lt-noDefault>base direction</dfn></dt><dd>
     The <a>base direction</a> is the direction used when a string does not have a direction associated with it directly.
     It can be set in the <a>context</a> using the <code>@direction</code> key
-    whose value must be one of the strings `"ltr"`, `"rtl"`, or <code>null</code>.</dd>
+    whose value must be one of the strings `"ltr"`, `"rtl"`, or <code>null</code>.
+    See the <a data-cite="JSON-LD11#context-definitions">Context Definitions</a> section of JSON-LD 1.1 for a normative description.
+    </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-embedded-context">embedded context</dfn></dt><dd>
     An embedded <a>context</a> is a context which appears
     as the <code>@context</code> <a>entry</a> of one of the following:
@@ -198,7 +204,9 @@
     where the value is a <a>map</a>
     containing one or more <a>keyword</a> keys to define the associated <a>IRI</a>,
     if this is a reverse property,
-    the type associated with string values, and a container mapping.</dd>
+    the type associated with string values, and a container mapping.
+    See the <a data-cite="JSON-LD11#expanded-term-definition">Expanded Term Definition</a> section of JSON-LD 1.1 for a normative description.
+  </dd>
   <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-frame" data-lt="frame|JSON-LD frame">frame</dfn></dt><dd>
     A <a>JSON-LD document</a>,
     which describes the form for transforming another <a>JSON-LD document</a>
@@ -209,7 +217,9 @@
     A frame object is a <a>map</a> element within a <a>frame</a>
     which represents a specific portion of the <a>frame</a> matching either
     a <a>node object</a> or a <a>value object</a>
-    in the input.</dd>
+    in the input.
+    See the <a data-cite="JSON-LD11#frame-objects">Frame Objects</a> section of JSON-LD 1.1 for a normative description.
+  </dd>
   <dt class="changed"><dfn data-cite="JSON-LD11#dfn-graph-object">graph object</dfn></dt><dd class="changed">
     A <a>graph object</a> represents a <a>named graph</a>
     as the value of a <a>map entry</a> within a <a>node object</a>.
@@ -220,7 +230,9 @@
     Note that <a>node objects</a> may have a <code>@graph</code> <a>entry</a>,
     but are not considered <a>graph objects</a> if they include any other <a>entries</a>.
     A top-level object consisting of <code>@graph</code> is also not a <a>graph object</a>.
-    Note that a <a>node object</a> may also represent a <a>named graph</a> it it includes other properties.</dd>
+    Note that a <a>node object</a> may also represent a <a>named graph</a> it it includes other properties.
+    See the <a data-cite="JSON-LD11#graph-objects">Graph Objects</a> section of JSON-LD 1.1 for a normative description.
+  </dd>
   <dt class="changed"><dfn data-cite="JSON-LD11#dfn-id-map">id map</dfn></dt><dd class="changed">
     An <a>id map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@id</code>.
@@ -228,14 +240,18 @@
     and its keys are interpreted as <a>IRIs</a> representing
     the <code>@id</code> of the associated <a>node object</a>.
     If a value in the <a>id map</a> contains a key expanding to <code>@id</code>,
-    its value must be equivalent to the referencing key in the <a>id map</a>.</dd>
+    its value must be equivalent to the referencing key in the <a>id map</a>.
+    See the <a data-cite="JSON-LD11#id-maps">Id Maps</a> section of JSON-LD 1.1 for a normative description.
+  </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-implicitly-named-graph">implicitly named graph</dfn></dt><dd>
     A <a>named graph</a> created from the value of a <a>map entry</a>
     having an <a>expanded term definition</a>
     where <code>@container</code> is set to  <code>@graph</code>.</dd>
   <dt class="changed"><dfn data-cite="JSON-LD11#dfn-included-block">included block</dfn></dt><dd class="changed">
     An <a>included block</a> is an <a>entry</a> in a <a>node object</a> where the key is either `@included` or an alias of `@included`
-    and the value is one or more <a>node objects</a>.</dd>
+    and the value is one or more <a>node objects</a>.
+    See the <a data-cite="JSON-LD11#included-blocks">Included Blocks</a> section of JSON-LD 1.1 for a normative description.
+  </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-index-map">index map</dfn></dt><dd>
     An <a>index map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@index</code>,
@@ -250,18 +266,23 @@
     <a>list object</a>,
     <a>set object</a>, or
     an <a>array</a> of zero or more of the above possibilities.
+    See the <a data-cite="JSON-LD11#index-maps">Index Maps</a> section in JSON-LD 1.1 for a formal description.
   </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-json-literal">JSON literal</dfn></dt><dd>
     A <a>JSON literal</a> is a <a>literal</a> where the associated <a>datatype IRI</a> is <code>rdf:JSON</code>.
     In the <a>value object</a> representation, the value of <code>@type</code> is <code>@json</code>.
     JSON literals represent values which are valid JSON [[RFC8259]].
-    See <dfn data-cite="JSON-LD11#dfn-json-datatype" data-cite="JSON-LD11#dfn-json-datatype" class="preserve">JSON datatype</dfn> in JSON-LD 1.1.
+    See the <a data-cite="JSON-LD11#the-rdf-json-datatype">The `rdf:JSON` Datatype</a> section in JSON-LD 1.1 for a normative description.
   </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-json-ld-document">JSON-LD document</dfn></dt><dd>
     A <a>JSON-LD document</a> is a serialization of
-    an <a>RDF dataset</a>.</dd>
+    an <a>RDF dataset</a>.
+    See the <a data-cite="JSON-LD11#json-ld-grammar">JSON-LD Grammar</a> section in JSON-LD 1.1 for a formal description.
+  </dd>
   <dt><dfn data-cite="JSON-LD11-API#dfn-json-ld-processor" data-lt="json-ld processor|Processors">JSON-LD Processor</dfn></dt><dd>
-    A <a>JSON-LD Processor</a> is a system which can perform the algorithms defined in JSON-LD 1.1 Processing Algorithms and API.</dd>
+    A <a>JSON-LD Processor</a> is a system which can perform the algorithms defined in JSON-LD 1.1 Processing Algorithms and API.
+    See the <a data-cite="JSON-LD11-API#conformance">Conformance</a> section in JSON-LD 1.1 API for a formal description.
+  </dd>
   <dt class="changed"><dfn data-cite="JSON-LD11-API#dfn-internal-representation" data-lt="internal representation">JSON-LD internal representation</dfn></dt><dd class="changed">
     The JSON-LD internal representation
     is the result of transforming a JSON syntactic structure
@@ -277,8 +298,9 @@
   </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-keyword">keyword</dfn></dt><dd>
     A <a>string</a> that is specific to JSON-LD,
-    specified in JSON-LD 1.1
-    in the section titled <a data-cite="JSON-LD11#syntax-tokens-and-keywords">Syntax Tokens and Keywords</a>.</dd>
+    described in the <a data-cite="JSON-LD11#syntax-tokens-and-keywords">Syntax Tokens and Keywords</a> section of JSON-LD 1.1,
+    and normatively specified in the <a data-cite="JSON-LD11#keywords">Keywords</a> section of JSON-LD 1.1,
+  </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-language-map">language map</dfn></dt><dd>
     An <a>language map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@language</code>,
@@ -287,10 +309,13 @@
     <a>null</a>,
     <a>string</a>, or
     an <a>array</a> of zero or more of the above possibilities.
+    See the <a data-cite="JSON-LD11#language-maps">Language Maps</a> section of JSON-LD 1.1 for a normative description.
   </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-list-object">list object</dfn></dt><dd>
     A <a>list object</a> is a <a>map</a> that has a <code>@list</code> key.
-    It may also have an <code>@index</code> key, but no other <a>entries</a>.</dd>
+    It may also have an <code>@index</code> key, but no other <a>entries</a>.
+    See the <a data-cite="JSON-LD11#lists-and-sets">Lists and Sets</a> section of JSON-LD 1.1 for a normative description.
+  </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-local-context">local context</dfn></dt><dd>
     A <a>context</a> that is specified with a <a>map</a>,
     specified via the <code>@context</code> <a>keyword</a>.</dd>
@@ -298,6 +323,7 @@
     A <a>nested property</a> is a key in a <a>node object</a>
     whose value is a <a>map</a> containing <a>entries</a> which are treated as if they were values of the <a>node object</a>.
     The <a>nested property</a> itself is semantically meaningless and used only to create a sub-structure within a <a>node object</a>.
+    See the <a data-cite="JSON-LD11#property-nesting">Property Nesting</a> section of JSON-LD 1.1 for a normative description.
   </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-node-object">node object</dfn></dt><dd>
     A <a>node object</a> represents zero or more <a>properties</a> of a <a>node</a> in the <a>graph</a>
@@ -310,6 +336,7 @@
         consisting of no other <a>entries</a> than <code>@graph</code> and <code>@context</code>.</li>
     </ul>
     The <a>entries</a> of a <a>node object</a> whose keys are not keywords are also called <a>properties</a> of the <a>node object</a>.
+    See the <a data-cite="JSON-LD11#node-objects">Node Objects</a> section of JSON-LD 1.1 for a normative description.
   </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-node-reference">node reference</dfn></dt><dd>
     A <a>node object</a> used to reference a node having only the <code>@id</code> key.</dd>
@@ -331,10 +358,13 @@
     via the `json-ld-1.1` <a>processing mode</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-set-object">set object</dfn></dt><dd>
     A <a>set object</a> is a <a>map</a> that has an <code>@set</code> <a>entry</a>.
-    It may also have an <code>@index</code> key, but no other <a>entries</a>.</dd>
+    It may also have an <code>@index</code> key, but no other <a>entries</a>.
+    See the <a data-cite="JSON-LD11#lists-and-sets">Lists and Sets</a> section of JSON-LD 1.1 for a normative description.
+  </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-term">term</dfn></dt><dd>
     A <a>term</a> is a short word defined in a <a>context</a>
     that may be expanded to an <a>IRI</a>.
+    See the <a data-cite="JSON-LD11#terms">Terms</a> section of JSON-LD 1.1 for a normative description.
   </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-term-definition">term definition</dfn></dt><dd>
     A term definition is an entry in a <a>context</a>,
@@ -352,7 +382,9 @@
     representing the <code>@type</code> of the associated <a>node object</a>;
     the value must be a <a>node object</a>, or <a>array</a> of node objects.
     If the value contains a <a>term</a> expanding to <code>@type</code>,
-    its values are merged with the map value when expanding.</dd>
+    its values are merged with the map value when expanding.
+    See the <a data-cite="JSON-LD11#type-maps">Type Maps</a> section of JSON-LD 1.1 for a normative description.
+  </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-typed-value" class="preserve">typed value</dfn></dt><dd>
     A <a>typed value</a> consists of a value,
     which is a <a>string</a>,
@@ -362,6 +394,8 @@
     A <a>value object</a> is a <a>map</a> that has an <code>@value</code> <a>entry</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-vocabulary-mapping" class="preserve">vocabulary mapping</dfn></dt><dd>
     The vocabulary mapping is set in the <a>context</a> using the <code>@vocab</code> key
-    whose value must be an <a>IRI</a>, a <a>compact IRI</a>, a <a>term</a>, or <code>null</code>.</dd>
+    whose value must be an <a>IRI</a>, a <a>compact IRI</a>, a <a>term</a>, or <code>null</code>.
+    See the <a data-cite="JSON-LD11#value-objects">Value Objects</a> section of JSON-LD 1.1 for a normative description.
+  </dd>
 </dl>
 </section>

--- a/common/terms.html
+++ b/common/terms.html
@@ -23,7 +23,7 @@
     A single colon comes after each name,
     separating the name from the value.
     A single comma separates a value from a following name.
-    In JSON-LD the names in an object MUST be unique.
+    In JSON-LD the names in an object must be unique.
     <p>In the <a>internal representation</a> a <a>JSON object</a> is described as a
       <dfn data-cite="INFRA#ordered-map" class="preserve">map</dfn> (see [[INFRA]]),
       composed of <dfn data-cite="INFRA#map-entry" data-lt="map entry|entry" data-ld-noDefault class="preserve">entries</dfn> with key/value pairs.</p>
@@ -104,16 +104,16 @@
     A <a>datatype IRI</a> is an <a>IRI</a> identifying a datatype that determines how the lexical form maps to a
     <a data-cite="RDF11-CONCEPTS#dfn-literal-value">literal value</a>.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-default-graph" class="preserve">default graph</dfn></dt><dd>
-    The <a>default graph</a> of a <a>dataset</a> is an <a>RDF graph</a> having no <a data-lt="graph name">name</a>, which MAY be empty.</dd>
+    The <a>default graph</a> of a <a>dataset</a> is an <a>RDF graph</a> having no <a data-lt="graph name">name</a>, which may be empty.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-graph-name" class="preserve">graph name</dfn></dt><dd>
     The <a>IRI</a> or <a>blank node</a> identifying a <a>named graph</a>.</dd>
   <dt><dfn data-cite="RDF11-CONCEPTS#dfn-language-tagged-string" class="preserve">language-tagged string</dfn></dt><dd>
     A <a>language-tagged string</a>
     consists of a string and a non-empty language tag
     as defined by [[BCP47]].
-    The <dfn data-cite="RDF11-CONCEPTS#dfn-language-tag">language tag</dfn> MUST be well-formed
+    The <dfn data-cite="RDF11-CONCEPTS#dfn-language-tag">language tag</dfn> must be well-formed
     according to <a data-cite="BCP47#section-2.2.9">section 2.2.9 Classes of Conformance</a> of [[BCP47]].
-    <span class="changed note">Processors MAY normalize <a>language tags</a> to lowercase.</span>
+    <span class="changed note">Processors may normalize <a>language tags</a> to lowercase.</span>
   </dd>
   <dt><dfn data-cite="LINKED-DATA" data-no-xref="" class="preserve">Linked Data</dfn></dt><dd>
     A set of documents, each containing a representation of a <a>linked data graph</a> or <a>dataset</a>.</dd>
@@ -171,13 +171,13 @@
   <dt><dfn data-cite="JSON-LD11#dfn-default-language">default language</dfn></dt><dd>
     The <a>default language</a> is the language used when a string does not have a language associated with it directly.
     It can be set in the <a>context</a> using the <code>@language</code> key
-    whose value MUST be a <a>string</a> representing a [[BCP47]] language code or <code>null</code>.</dd>
+    whose value must be a <a>string</a> representing a [[BCP47]] language code or <code>null</code>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-default-object">default object</dfn></dt><dd>
     A <a>default object</a> is a <a>map</a> that has a <code>@default</code> key.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-base-direction" data-lt="base direction|default base direction" data-lt-noDefault>base direction</dfn></dt><dd>
     The <a>base direction</a> is the direction used when a string does not have a direction associated with it directly.
     It can be set in the <a>context</a> using the <code>@direction</code> key
-    whose value MUST be one of the strings `"ltr"`, `"rtl"`, or <code>null</code>.</dd>
+    whose value must be one of the strings `"ltr"`, `"rtl"`, or <code>null</code>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-embedded-context">embedded context</dfn></dt><dd>
     An embedded <a>context</a> is a context which appears
     as the <code>@context</code> <a>entry</a> of one of the following:
@@ -213,8 +213,8 @@
   <dt class="changed"><dfn data-cite="JSON-LD11#dfn-graph-object">graph object</dfn></dt><dd class="changed">
     A <a>graph object</a> represents a <a>named graph</a>
     as the value of a <a>map entry</a> within a <a>node object</a>.
-    When expanded, a graph object MUST have an <code>@graph</code> <a>entry</a>,
-    and MAY also have <code>@id</code>, and <code>@index</code> <a>entries</a>.
+    When expanded, a graph object must have an <code>@graph</code> <a>entry</a>,
+    and may also have <code>@id</code>, and <code>@index</code> <a>entries</a>.
     A <dfn data-cite="JSON-LD11#dfn-simple-graph-object" class="preserve">simple graph object</dfn>
     is a <a>graph object</a> which does not have an <code>@id</code> <a>entry</a>.
     Note that <a>node objects</a> may have a <code>@graph</code> <a>entry</a>,
@@ -224,11 +224,11 @@
   <dt class="changed"><dfn data-cite="JSON-LD11#dfn-id-map">id map</dfn></dt><dd class="changed">
     An <a>id map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@id</code>.
-    The values of the <a>id map</a> MUST be <a>node objects</a>,
+    The values of the <a>id map</a> must be <a>node objects</a>,
     and its keys are interpreted as <a>IRIs</a> representing
     the <code>@id</code> of the associated <a>node object</a>.
     If a value in the <a>id map</a> contains a key expanding to <code>@id</code>,
-    its value MUST be equivalent to the referencing key in the <a>id map</a>.</dd>
+    its value must be equivalent to the referencing key in the <a>id map</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-implicitly-named-graph">implicitly named graph</dfn></dt><dd>
     A <a>named graph</a> created from the value of a <a>map entry</a>
     having an <a>expanded term definition</a>
@@ -239,7 +239,7 @@
   <dt><dfn data-cite="JSON-LD11#dfn-index-map">index map</dfn></dt><dd>
     An <a>index map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@index</code>,
-    whose values MUST be any of the following types:
+    whose values must be any of the following types:
     <a>string</a>,
     <a>number</a>,
     <code>true</code>,
@@ -282,8 +282,8 @@
   <dt><dfn data-cite="JSON-LD11#dfn-language-map">language map</dfn></dt><dd>
     An <a>language map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@language</code>,
-    whose keys MUST be <a>strings</a> representing [[BCP47]] language codes
-    and the values MUST be any of the following types:
+    whose keys must be <a>strings</a> representing [[BCP47]] language codes
+    and the values must be any of the following types:
     <a>null</a>,
     <a>string</a>, or
     an <a>array</a> of zero or more of the above possibilities.
@@ -334,7 +334,7 @@
     It may also have an <code>@index</code> key, but no other <a>entries</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-term">term</dfn></dt><dd>
     A <a>term</a> is a short word defined in a <a>context</a>
-    that MAY be expanded to an <a>IRI</a>.
+    that may be expanded to an <a>IRI</a>.
   </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-term-definition">term definition</dfn></dt><dd>
     A term definition is an entry in a <a>context</a>,
@@ -350,7 +350,7 @@
     defined with <code>@container</code> set to <code>@type</code>,
     whose keys are interpreted as <a>IRIs</a>
     representing the <code>@type</code> of the associated <a>node object</a>;
-    the value MUST be a <a>node object</a>, or <a>array</a> of node objects.
+    the value must be a <a>node object</a>, or <a>array</a> of node objects.
     If the value contains a <a>term</a> expanding to <code>@type</code>,
     its values are merged with the map value when expanding.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-typed-value" class="preserve">typed value</dfn></dt><dd>
@@ -362,6 +362,6 @@
     A <a>value object</a> is a <a>map</a> that has an <code>@value</code> <a>entry</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-vocabulary-mapping" class="preserve">vocabulary mapping</dfn></dt><dd>
     The vocabulary mapping is set in the <a>context</a> using the <code>@vocab</code> key
-    whose value MUST be an <a>IRI</a>, a <a>compact IRI</a>, a <a>term</a>, or <code>null</code>.</dd>
+    whose value must be an <a>IRI</a>, a <a>compact IRI</a>, a <a>term</a>, or <code>null</code>.</dd>
 </dl>
 </section>

--- a/index.html
+++ b/index.html
@@ -12477,10 +12477,16 @@ the data type to be specified explicitly with each piece of data.</p>
     </dd>
     <dt><code>@language</code></dt><dd>
       The <code>@language</code> keyword MAY be aliased and MAY be used as a key in a <a>value object</a>.
-      Its value MUST be a <a>string</a> with the <a data-cite="BCP47#section-2.1.1">lexical form</a> described in [[BCP47]] or be <a>null</a>..
+      Its value MUST be a <a>string</a> with the <a data-cite="BCP47#section-2.1.1">lexical form</a> described in [[BCP47]] or be <a>null</a>.
       <p>The unaliased <code>@language</code> MAY be used as a key in a <a>context definition</a>,
         or as the value of the <code>@container</code> key within an <a>expanded term definition</a>.</p>
-      <p>See <a class="sectionRef" href="#index-maps"></a> for a further discussion.</p>
+      <p>See <a class="sectionRef" href="#string-internationalization"></a>, <a class="sectionRef" href="#language-maps"></a>.</p>
+    </dd>
+    <dt>`@direction`</dt><dd>
+      The <code>@direction</code> keyword MAY be aliased and MAY be used as a key in a <a>value object</a>.
+      Its value MUST be one of <code>"ltr"</code> or <code>"rtl"</code>, or be <a>null</a>.
+      <p>The unaliased <code>@direction</code> MAY be used as a key in a <a>context definition</a>.</p>
+      <p>See <a class="sectionRef" href="#base-direction"></a> for a further discussion.</p>
     </dd>
     <dt><code>@list</code></dt><dd>
       The <code>@list</code> keyword MAY be aliased and MUST be used as a key in a <a>list object</a>.
@@ -12600,6 +12606,12 @@ the data type to be specified explicitly with each piece of data.</p>
       its value MUST be an <a>included block</a>.
       This keyword is described further in <a class="sectionRef" href="#included-nodes"></a>,
       and <a class="sectionRef" href="#included-blocks"></a>.
+    </dd>
+    <dt>`@json`</dt><dd>
+      The <code>@json</code> keyword MAY be aliased
+      and MAY be used as the value of the `@type` key within a <a>value object</a>
+      or an <a>expanded term definition</a>.
+      <p>See <a class="sectionRef" href="#json-literals"></a>.</p>
     </dd>
   </dl>
 </section>

--- a/index.html
+++ b/index.html
@@ -533,11 +533,13 @@
         JSON document.</p>
   </section>
 
-  <section class="normative">
+  <section class="informative">
     <h2>Syntax Tokens and Keywords</h2>
 
     <p>JSON-LD specifies a number of syntax tokens and <a>keywords</a>
-    that are a core part of the language:</p>
+    that are a core part of the language.
+    A normative description of the <a>keywords</a> is given in <a class="sectionRef" href="#keywords"></a>.
+    </p>
 
     <dl data-sort>
       <dt><code>@context</code></dt>

--- a/index.html
+++ b/index.html
@@ -12270,13 +12270,16 @@ the data type to be specified explicitly with each piece of data.</p>
     its value MUST be an <a>IRI reference</a>,
     or <a>null</a>.</p>
 
+  <p>If the <a>context definition</a> has an <code>@direction</code> key,
+    its value MUST be one of <code>"ltr"</code> or <code>"rtl"</code>, or be <a>null</a>.</p>
+
+  <p class="changed">If the <a>context definition</a> contains the <code>@import</code>
+  <a>keyword</a>, its value MUST be an <a>IRI reference</a>.
+  When used as a reference from an `@import`, the referenced <a>context definition</a> MUST NOT
+  include an `@import` key, itself.</p>
+
   <p>If the <a>context definition</a> has an <code>@language</code> key,
     its value MUST have the <a data-cite="BCP47#section-2.1.1">lexical form</a> described in [[BCP47]] or be <a>null</a>.</p>
-
-  <p class="changed">If a <a>context</a> contains the <code>@import</code>
-    <a>keyword</a>, its value MUST be an <a>IRI reference</a>.
-    When used as a reference from an `@import`, the referenced <a>context definition</a> MUST NOT
-    include an `@import` key, itself.</p>
 
   <p class="changed">If the <a>context definition</a> has an <code>@propagate</code> key,
     its value MUST be <code>true</code> or <code>false</code>.</p>
@@ -12301,108 +12304,107 @@ the data type to be specified explicitly with each piece of data.</p>
     a <a>blank node identifier</a>, a <a>keyword</a>, <a>null</a>,
     or an <a>expanded term definition</a>.</p>
 
-  <p>An <a>expanded term definition</a> is used to describe the mapping
+
+  <section><h3>Expanded term definition</h3>
+    <p>An <a>expanded term definition</a> is used to describe the mapping
     between a <a>term</a> and its expanded identifier, as well as other
     properties of the value associated with the <a>term</a> when it is
     used as key in a <a>node object</a>.</p>
 
-  <p>An <a>expanded term definition</a> MUST be a <a>map</a>
-    composed of zero or more keys from
-    <code>@id</code>,
-    <code>@reverse</code>,
-    <code>@type</code>,
-    <code>@language</code>,
-    <code>@container</code>,
-    <code class="changed">@context</code>,
-    <code class="changed">@prefix</code>,
-    <code class="changed">@propagate</code>, or
-    <code class="changed">@protected</code>.
-    An <a>expanded term definition</a> SHOULD NOT contain any other keys.</p>
+    <p>An <a>expanded term definition</a> MUST be a <a>map</a>
+      composed of zero or more keys from
+      <code>@id</code>,
+      <code>@reverse</code>,
+      <code>@type</code>,
+      <code>@language</code>,
+      <code>@container</code>,
+      <code class="changed">@context</code>,
+      <code class="changed">@prefix</code>,
+      <code class="changed">@propagate</code>, or
+      <code class="changed">@protected</code>.
+      An <a>expanded term definition</a> SHOULD NOT contain any other keys.</p>
 
-  <p class="changed">When the associated term is `@type`, the <a>expanded term definition</a>
-    MUST NOT contain keys other than `@container` and `@protected`.
-    The value of `@container` is limited to the single value `@set`.</p>
+    <p class="changed">When the associated term is `@type`, the <a>expanded term definition</a>
+      MUST NOT contain keys other than `@container` and `@protected`.
+      The value of `@container` is limited to the single value `@set`.</p>
 
-  <p>If the term being defined is not an <a>IRI</a> or a <a>compact IRI</a>
-    and the <a>active context</a> does not have an
-    <code>@vocab</code> mapping, the <a>expanded term definition</a> MUST
-    include the <code>@id</code> key.</p>
+    <p>If the term being defined is not an <a>IRI</a> or a <a>compact IRI</a>
+      and the <a>active context</a> does not have an
+      <code>@vocab</code> mapping, the <a>expanded term definition</a> MUST
+      include the <code>@id</code> key.</p>
 
-  <p class="changed"><a>Term definitions</a> with keys which are of the form of an <a>IRI</a> or a <a>compact IRI</a> MUST NOT
-    expand to an <a>IRI</a> other than the expansion of the key itself.</p>
+    <p class="changed"><a>Term definitions</a> with keys which are of the form of an <a>IRI</a> or a <a>compact IRI</a> MUST NOT
+      expand to an <a>IRI</a> other than the expansion of the key itself.</p>
 
-  <p>If the <a>expanded term definition</a> contains the <code>@id</code>
-    <a>keyword</a>, its value MUST be <a>null</a>, an <a>IRI</a>,
-    a <a>blank node identifier</a>, a <a>compact IRI</a>, a <a>term</a>,
-    or a <a>keyword</a>.</p>
+    <p>If the <a>expanded term definition</a> contains the <code>@id</code>
+      <a>keyword</a>, its value MUST be <a>null</a>, an <a>IRI</a>,
+      a <a>blank node identifier</a>, a <a>compact IRI</a>, a <a>term</a>,
+      or a <a>keyword</a>.</p>
 
-  <p>If an <a>expanded term definition</a> has an <code>@reverse</code> <a>entry</a>,
-    it MUST NOT have <code>@id</code> or <code>@nest</code> <a>entries</a> at the same time,
-    its value MUST be an <a>IRI</a>,
-    a <a>blank node identifier</a>, a <a>compact IRI</a>, or a <a>term</a>. If an
-    <code>@container</code> <a>entry</a> exists, its value MUST be <a>null</a>,
-    <code>@set</code>, or <code>@index</code>.</p>
+    <p>If an <a>expanded term definition</a> has an <code>@reverse</code> <a>entry</a>,
+      it MUST NOT have <code>@id</code> or <code>@nest</code> <a>entries</a> at the same time,
+      its value MUST be an <a>IRI</a>,
+      a <a>blank node identifier</a>, a <a>compact IRI</a>, or a <a>term</a>. If an
+      <code>@container</code> <a>entry</a> exists, its value MUST be <a>null</a>,
+      <code>@set</code>, or <code>@index</code>.</p>
 
-  <p>If the <a>expanded term definition</a> contains the <code>@type</code>
-    <a>keyword</a>, its value MUST be an <a>IRI</a>, a
-    <a>compact IRI</a>, a <a>term</a>, <a>null</a>, or one of the
-    <a>keywords</a> <code>@id</code>, <code class="changed">@json</code>, <code class="changed">@none</code>, or <code>@vocab</code>.</p>
+    <p>If the <a>expanded term definition</a> contains the <code>@type</code>
+      <a>keyword</a>, its value MUST be an <a>IRI</a>, a
+      <a>compact IRI</a>, a <a>term</a>, <a>null</a>, or one of the
+      <a>keywords</a> <code>@id</code>, <code class="changed">@json</code>, <code class="changed">@none</code>, or <code>@vocab</code>.</p>
 
-  <p>If the <a>expanded term definition</a> contains the <code>@language</code> <a>keyword</a>,
-    its value MUST have the <a data-cite="BCP47#section-2.1.1">lexical form</a> described in [[BCP47]] or be <a>null</a>.</p>
+    <p>If the <a>expanded term definition</a> contains the <code>@language</code> <a>keyword</a>,
+      its value MUST have the <a data-cite="BCP47#section-2.1.1">lexical form</a> described in [[BCP47]] or be <a>null</a>.</p>
 
-  <p>If the <a>expanded term definition</a> contains the <code>@container</code>
-    <a>keyword</a>, its value MUST be either
-    <code>@list</code>,
-    <code>@set</code>,
-    <code>@language</code>,
-    <code>@index</code>,
-    <span class="changed"><code>@id</code></span>,
-    <span class="changed"><code>@graph</code></span>,
-    <span class="changed"><code>@type</code></span>, or be
-    <a>null</a>
-    <span class="changed">
-      or an <a>array</a> containing exactly any one of those keywords, or a
-      combination of <code>@set</code> and any of <code>@index</code>,
-      <code>@id</code>, <code>@graph</code>, <code>@type</code>,
-      <code>@language</code> in any order
-    </span>.
-    <span class="changed"><code>@container</code> may also be an array
-      containing <code>@graph</code> along with either <code>@id</code> or
-      <code>@index</code> and also optionally including <code>@set</code>.</span>
-    If the value
-    is <code>@language</code>, when the <a>term</a> is used outside of the
-    <code>@context</code>, the associated value MUST be a <a>language map</a>.
-    If the value is <code>@index</code>, when the <a>term</a> is used outside of
-    the <code>@context</code>, the associated value MUST be an
-    <a>index map</a>.</p>
+    <p>If the <a>expanded term definition</a> contains the <code>@container</code>
+      <a>keyword</a>, its value MUST be either
+      <code>@list</code>,
+      <code>@set</code>,
+      <code>@language</code>,
+      <code>@index</code>,
+      <span class="changed"><code>@id</code></span>,
+      <span class="changed"><code>@graph</code></span>,
+      <span class="changed"><code>@type</code></span>, or be
+      <a>null</a>
+      <span class="changed">
+        or an <a>array</a> containing exactly any one of those keywords, or a
+        combination of <code>@set</code> and any of <code>@index</code>,
+        <code>@id</code>, <code>@graph</code>, <code>@type</code>,
+        <code>@language</code> in any order
+      </span>.
+      <span class="changed"><code>@container</code> may also be an array
+        containing <code>@graph</code> along with either <code>@id</code> or
+        <code>@index</code> and also optionally including <code>@set</code>.</span>
+      If the value
+      is <code>@language</code>, when the <a>term</a> is used outside of the
+      <code>@context</code>, the associated value MUST be a <a>language map</a>.
+      If the value is <code>@index</code>, when the <a>term</a> is used outside of
+      the <code>@context</code>, the associated value MUST be an
+      <a>index map</a>.</p>
 
-  <p class="changed">If an <a>expanded term definition</a> has an <code>@context</code> <a>entry</a>,
-    it MUST be a valid <code>context definition</code>.</p>
+    <p class="changed">If an <a>expanded term definition</a> has an <code>@context</code> <a>entry</a>,
+      it MUST be a valid <code>context definition</code>.</p>
 
-  <p class="changed">If a <a>context</a> contains the <code>@import</code>
-    <a>keyword</a>, its value MUST be an <a>IRI reference</a>.
-    When used as a reference from an `@import`, the referenced <a>context definition</a> MUST NOT
-    include an `@import` key, itself.</p>
+    <p class="changed">If the <a>expanded term definition</a> contains the <code>@nest</code>
+      <a>keyword</a>, its value MUST be either <code>@nest</code>, or a term
+      which expands to <code>@nest</code>.</p>
 
-  <p class="changed">If the <a>expanded term definition</a> contains the <code>@nest</code>
-    <a>keyword</a>, its value MUST be either <code>@nest</code>, or a term
-    which expands to <code>@nest</code>.</p>
+    <p class="changed">If the <a>expanded term definition</a> contains the <code>@prefix</code>
+      <a>keyword</a>, its value MUST be <code>true</code> or <code>false</code>.</p>
 
-  <p class="changed">If the <a>expanded term definition</a> contains the <code>@prefix</code>
-    <a>keyword</a>, its value MUST be <code>true</code> or <code>false</code>.</p>
+    <p class="changed">If the <a>expanded term definition</a> contains the <code>@propagate</code>
+      <a>keyword</a>, its value MUST be <code>true</code> or <code>false</code>.</p>
 
-  <p class="changed">If the <a>expanded term definition</a> contains the <code>@propagate</code>
-    <a>keyword</a>, its value MUST be <code>true</code> or <code>false</code>.</p>
+    <p class="changed">If the <a>expanded term definition</a> contains the <code>@protected</code>
+      <a>keyword</a>, its value MUST be <code>true</code> or <code>false</code>.</p>
 
-  <p class="changed">If the <a>expanded term definition</a> contains the <code>@protected</code>
-    <a>keyword</a>, its value MUST be <code>true</code> or <code>false</code>.</p>
+    <p><a>Terms</a> MUST NOT be used in a circular manner. That is,
+      the definition of a term cannot depend on the definition of another term if that other
+      term also depends on the first term.</p>
 
-  <p><a>Terms</a> MUST NOT be used in a circular manner. That is,
-    the definition of a term cannot depend on the definition of another term if that other
-    term also depends on the first term.</p>
+  </section>
 
-  <p>See <a class="sectionRef" href="#the-context"></a> for further discussion on contexts.</p>
+  <p>See <a class="sectionRef" href="#the-context"></a> for further discussion on <a>contexts</a>.</p>
 </section>
 
 <section class="normative">

--- a/index.html
+++ b/index.html
@@ -1372,7 +1372,7 @@
 
 </section>
 
-<section class="changed">
+<section class="changed informative">
   <h2>Uses of JSON Objects</h2>
   <p>As a syntax, JSON has only a limited number of syntactic elements:</p>
   <ul>

--- a/index.html
+++ b/index.html
@@ -1665,7 +1665,7 @@
 </section>
 </section>
 
-<section class="normative">
+<section class="informative">
 <h1>Advanced Concepts</h1>
 
 <p>JSON-LD has a number of features that provide functionality above and beyond
@@ -2593,7 +2593,7 @@
     external contexts.</p>
 </section>
 
-<section id="document-relative-vocabulary-mapping" class="changed">
+<section id="document-relative-vocabulary-mapping" class="changed informative">
   <h3>Using the Document Base for the Default Vocabulary</h3>
   <p>In some cases, vocabulary terms are defined directly within the document
     itself, rather than in an external vocabulary.

--- a/index.html
+++ b/index.html
@@ -432,7 +432,7 @@
     <div data-include="common/typographical-conventions.html"></div>
   </section>
 
-  <section class="normative">
+  <section class="informative">
     <h2>Terminology</h2>
 
     <p>This document uses the following terms as defined in external specifications
@@ -11558,7 +11558,9 @@ the data type to be specified explicitly with each piece of data.</p>
       consists of a string and a non-empty <a>language tag</a> as defined by [[BCP47]].
       The language tag MUST be well-formed according to section
       <a data-cite="BCP47#section-2.2.9">2.2.9 Classes of Conformance</a>
-      of [[BCP47]].</li>
+      of [[BCP47]].
+      <span class="changed note">Processors MAY normalize <a>language tags</a> to lowercase.</span>
+      </li>
     <li class="changed">Either <a>strings</a>, or <a>language-tagged strings</a> may include
       a <a>base direction</a>, which represents an extension to the underlying
       <a data-cite="RDF11-CONCEPTS#data-model">RDF data model</a>.</li>
@@ -11763,7 +11765,7 @@ the data type to be specified explicitly with each piece of data.</p>
   <section id="terms" class="normative">
     <h2>Terms</h2>
 
-    <p>A <a>term</a> is a short-hand <a>string</a> that expands
+    <p>A <a>term</a> is a short-hand <a>string</a> that MAY expand
       to an <a>IRI</a>, <a>blank node identifier</a>, or <a>keyword</a>.</p>
 
     <p>A <a>term</a> MUST NOT equal any of the JSON-LD <a>keywords</a>,

--- a/index.html
+++ b/index.html
@@ -11765,7 +11765,7 @@ the data type to be specified explicitly with each piece of data.</p>
   <section id="terms" class="normative">
     <h2>Terms</h2>
 
-    <p>A <a>term</a> is a short-hand <a>string</a> that MAY expand
+    <p>A <a>term</a> is a short-hand <a>string</a> that expands
       to an <a>IRI</a>, <a>blank node identifier</a>, or <a>keyword</a>.</p>
 
     <p>A <a>term</a> MUST NOT equal any of the JSON-LD <a>keywords</a>,


### PR DESCRIPTION
Addresses #294 .

Two remarks about this PR:

* due to some sections not being normative anymore, 5 references have moved from normative references to non-normative references:

  * INFRA
  *JSON-LD10 (now duplicated with JSON-LD, btw)
  * LINKED DATA
  * RFC5234 (ANBF)
  * WEBIDL

  I don't think any of this is a problem for the SYNTAX document, but others might disagree.

* Should term mentions in the rest of the document (and other documents) point to the normative definition in §9 rather than to §1.4? It seems to make more sense, but on the other hand, definitions in §1.4 are more explicative and readable, and they point to examples in sections 3 and 4... Plus, I don't have the respec skill to do it (I tried and I failed).

  An alternative would be to add, in each definition where this is relevant, a link to the corresponding subsection of §9?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/295.html" title="Last updated on Nov 12, 2019, 11:05 PM UTC (c1878e1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/295/411f708...c1878e1.html" title="Last updated on Nov 12, 2019, 11:05 PM UTC (c1878e1)">Diff</a>