### PR TITLE
Fix Note for example 65

### DIFF
--- a/index.html
+++ b/index.html
@@ -4891,7 +4891,7 @@ the data type to be specified explicitly with each piece of data.</p>
   </pre>
 </aside>
 
-<p class="note">The triple <code>[] ex2:fred ex1:barney .</code> is emitted twice,
+<p class="note">The triple <code>ex1:fred ex2:knows ex1:barney .</code> is emitted twice,
   but exists only once in an output dataset, as it is a duplicate triple.</p>
 
 <p>Terms may also be defined using <a>IRIs</a>


### PR DESCRIPTION
The triple emitted twice is "ex2:fred ex2:knows ex1:barney"


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Fak3/json-ld-syntax/pull/314.html" title="Last updated on Nov 26, 2019, 9:52 AM UTC (89f3de4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/314/ee7f17d...Fak3:89f3de4.html" title="Last updated on Nov 26, 2019, 9:52 AM UTC (89f3de4)">Diff</a>