### PR TITLE
changed definition of the rdf:JSON datatype

### DIFF
--- a/index.html
+++ b/index.html
@@ -12858,48 +12858,15 @@ the data type to be specified explicitly with each piece of data.</p>
       <dd>is the set of UNICODE [[UNICODE]] strings which conform to the <a data-cite="JSON#section-2">JSON Grammar</a>
         as described in <a data-cite="RFC8259#section-2">Section 2 JSON Grammar</a> of [[RFC8259]].</dd>
       <dt>The value space</dt>
-      <dd class="algorithm">is the union of the four primitive types (<a>strings</a>, <a>numbers</a>, <a>booleans</a>,
-        and <a>null</a>) and two structured types (<a>objects</a> and <a>arrays</a>)
-        from [[ECMASCRIPT]].
-        Two JSON values <var>A</var> and <var>B</var> are considered equal if and only if the following is true:
-        <ol>
-          <li>If <var>A</var> and <var>B</var> are both <a>objects</a>,
-            both <var>A</var> and <var>B</var> have the same number of <a>entries</a>,
-            and each <a>entry</a> in <var>A</var> is equal to a corresponding <a>entry</a> in <var>B</var>
-            where <ul>
-              <li>the keys are equal (as defined in <a data-cite="ECMASCRIPT#sec-samevaluenonnumber">Section 7.2.13, step 5.a</a>
-                  in [[ECMASCRIPT]]), and</li>
-              <li>the values are considered equal through
-                applying this comparison recursively.</li>
-            </ul>
-          <li>Otherwise, if <var>A</var> and <var>B</var> are both <a>arrays</a>,
-            both <var>A</var> and <var>B</var> have the same number of elements,
-            and each element <var>A<sub>i</sub></var> is considered
-            equal to the corresponding element <var>B<sub>i</sub></var>
-            through applying this comparison recursively.</li>
-          <li>Otherwise, if <var>A</var> and <var>B</var> satisfy the
-            <a data-cite="ECMASCRIPT#sec-strict-equality-comparison">Strict Equality Comparison</a>
-            defined in <a data-cite="ECMASCRIPT#sec-strict-equality-comparison">Section 7.2.16</a> in [[ECMASCRIPT]].</li>
-          <li>Otherwise, <var>A</var> and <var>B</var> are not equal.</li>
-        </ol>
-      </dd>
-      <dt>The lexical-to-value mapping</dt>
-      <dd>is the result of parsing the lexical representation into
-        an internal representation consistent with [[ECMASCRIPT]] representation
-        created by using the <code>JSON.parse</code> function as defined in
-        <a data-cite="ECMASCRIPT#sec-json-object">Section 24.5 The JSON Object</a> of [[ECMASCRIPT]].</dd>
-      <dt>The canonical mapping</dt>
-      <dd>is non-normative, as a normative recommendation for
-        JSON canonicalization is not yet defined. Implementations
-        SHOULD use the following guidelines when creating the lexical
-        representation of a <a>JSON literal</a>:
-
-        <ul class="changed">
-          <li>Serialize JSON using no unnecessary whitespace,</li>
-          <li>Keys in objects SHOULD be ordered lexicographically,</li>
-          <li>Native Numeric values SHOULD be serialized according to
+      <dd class="changed">is the set of UNICODE [[UNICODE]] strings which conform to the <a data-cite="JSON#section-2">JSON Grammar</a>
+        as described in <a data-cite="RFC8259#section-2">Section 2 JSON Grammar</a> of [[RFC8259]],
+        and furthermore comply with the following constraints:
+        <ul>
+          <li>It MUST not contain any unnecessary whitespace,</li>
+          <li>Keys in objects MUST be ordered lexicographically,</li>
+          <li>Native Numeric values MUST be serialized according to
             <a data-cite="?ECMASCRIPT#sec-tostring-applied-to-the-number-type">Section 7.1.12.1</a> of [[?ECMASCRIPT]],</li>
-          <li>Strings SHOULD be serialized with Unicode codepoints from <code>U+0000</code> through <code>U+001F</code>
+          <li>Strings MUST be serialized with Unicode codepoints from <code>U+0000</code> through <code>U+001F</code>
             using lower case hexadecimal Unicode notation (<code>\uhhhh</code>) unless in the set
             of predefined JSON control characters <code>U+0008</code>, <code>U+0009</code>,
             <code>U+000A</code>, <code>U+000C</code> or <code>U+000D</code>
@@ -12908,7 +12875,6 @@ the data type to be specified explicitly with each piece of data.</p>
             <code>U+005C</code> (<code>\</code>) and <code>U+0022</code> (<code>"</code>)
             which SHOULD be serialized as <code>\\</code> and <code>\"</code> respectively.</li>
         </ul>
-
         <div class="issue changed">The JSON Canonicalization Scheme [[?JCS]]
           is an emerging standard for JSON canonicalization
           not yet ready to be referenced.
@@ -12917,7 +12883,25 @@ the data type to be specified explicitly with each piece of data.</p>
           Users are cautioned from depending on the
           <a>JSON literal</a> lexical representation as an <a>RDF literal</a>,
           as the specifics of serialization may change in a future revision of this document.</div>
+        Despite being defined as a set of strings,
+        this value space is considered distinct from the value space of `xsd:string`,
+        in order to avoid side effects with existing specifications.
       </dd>
+      <dt>The lexical-to-value mapping</dt>
+      <dd>maps any element of the lexical space to the result of
+        <ol>
+          <li>parsing it into
+            an internal representation consistent with [[ECMASCRIPT]] representation
+            created by using the <code>JSON.parse</code> function as defined in
+            <a data-cite="ECMASCRIPT#sec-json-object">Section 24.5 The JSON Object</a> of [[ECMASCRIPT]],</li>
+          <li>then serializing it in the JSON format [[RFC8259]]
+            in compliance with the constraints of the value space described above.
+          </li>
+        </ol>
+      </dd>
+      <dt>The canonical mapping</dt>
+      <dd>maps any element of the value space to the identical string in the lexical space.</dd>
+
     </dl>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -12862,7 +12862,7 @@ the data type to be specified explicitly with each piece of data.</p>
         as described in <a data-cite="RFC8259#section-2">Section 2 JSON Grammar</a> of [[RFC8259]],
         and furthermore comply with the following constraints:
         <ul>
-          <li>It MUST not contain any unnecessary whitespace,</li>
+          <li>It MUST NOT contain any unnecessary whitespace,</li>
           <li>Keys in objects MUST be ordered lexicographically,</li>
           <li>Native Numeric values MUST be serialized according to
             <a data-cite="?ECMASCRIPT#sec-tostring-applied-to-the-number-type">Section 7.1.12.1</a> of [[?ECMASCRIPT]],</li>
@@ -12901,7 +12901,6 @@ the data type to be specified explicitly with each piece of data.</p>
       </dd>
       <dt>The canonical mapping</dt>
       <dd>maps any element of the value space to the identical string in the lexical space.</dd>
-
     </dl>
   </section>
 


### PR DESCRIPTION
addressing #323

Note that the description of the canonical form, which used to be non-normative (and using SHOULD) is now normative and uses MUST. It seemed inappropriate to define the value space non-normatively... :-/

As a consequence, the corresponding text in [API 8.6 Data Round Tripping](http://localhost:8000/json-ld-api/#data-round-tripping) is states:

> The canonical lexical form of a JSON literal value is non-normative, 

and still uses SHOULD. I guess we should update it as well?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/325.html" title="Last updated on Jan 24, 2020, 4:37 PM UTC (a25e7e5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/325/597a8c4...a25e7e5.html" title="Last updated on Jan 24, 2020, 4:37 PM UTC (a25e7e5)">Diff</a>