### PR TITLE
Issue324

### DIFF
--- a/ack-script/acknowledgements.html
+++ b/ack-script/acknowledgements.html
@@ -7,6 +7,7 @@
 
     <ul class="ack">
                 <li>Timothy Cole (University of Illinois at Urbana-Champaign)</li>
+        <li>Gregory Todd Williams (J. Paul Getty Trust)</li>
         <li>Ivan Herman (W3C Staff)</li>
         <li>Jeff Mixter (OCLC (Online Computer Library Center, Inc.))</li>
         <li>David Lehn (Digital Bazaar)</li>

--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -9,6 +9,27 @@
     which is used for finding coercion mappings in the <a>active context</a>.</dd>
   <dt><dfn data-cite="JSON-LD11-API#dfn-active-subject">active subject</dfn></dt><dd>
     The currently active subject that the processor should use when processing.</dd>
+  <dt class="changed"><dfn data-cite="JSON-LD11-API#add-value">add value</dfn></dt>
+  <dd class="algorithm changed">
+    Used as a macro within various algorithms as a way to add a <var>value</var>
+    to an <a>entry</a> in a <a>map</a> (<var>object</var>) using a specified <var>key</var>.
+    The invocation may include an <var>as array</var> flag defaulting to <code>false</code>.
+    <ol>
+      <li>If <var>as array</var> is <code>true</code>,
+        and <var>value</var> is not an <a>array</a>,
+        set it to an <a>array</a> containing <var>value</var>.</li>
+      <li>If <var>key</var> is not an entry in <var>object</var>,
+        add <var>value</var> as the value of <var>key</var> in <var>object</var>.</li>
+      <li>Otherwise
+        <ol>
+          <li>If the value of <var>key</var> <a>entry</a> in <var>object</var> is not an <a>array</a>,
+            set it to a new <a>array</a> containing the original value.</li>
+          <li>If <var>value</var> is an <a>array</a>, concatenate <var>value</var>
+            to that <a>entry</a>.</li>
+          <li>Otherwise, append <var>value</var> to that <a>entry</a>.</li>
+        </ol>
+    </ol>
+  </dd>
   <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-expicit-inclusion-flag">explicit inclusion flag</dfn></dt><dd>
     A flag specifying that for <a>properties</a> to be included in the output,
     they must be explicitly declared in the matching <a>frame</a>.</dd>
@@ -20,6 +41,46 @@
     used internally to help determine if object embedding is appropriate,</span>
     the <a>explicit inclusion flag</a>,
     and the <a>omit default flag</a>.</dd>
+  <dt class="changed"><dfn data-cite="JSON-LD11-API#dfn-iri-compacting">IRI compacting</dfn></dt>
+  <dd class="algorithm changed">
+    Used as a macro within various algorithms as to reduce the language used to describe
+    the process of compacting a <a>string</a> <var>var</var> representing an <a>IRI</a> or <a>keyword</a>
+    using an <var>active context</var> either specified directly, or coming from the scope of
+    the algorithm step using this term and <var>inverse context</var> also taken
+    from the scope of the algorithm step using this term.
+    An optional <var>value</var> is used, if explicitly provided.
+    Unless specified,
+    the <var>vocab</var> flag defaults to `true`,
+    and the <var>reverse</var> flag defaults to `false`.
+    <ol>
+      <li>Return the result of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
+        passing <var>active context</var>, <var>inverse context</var>,
+        <var>var</var>,
+        <var>value</var> (if supplied),
+        <var>vocab</var>,
+        and <var>result</var>.</li>
+    </ol>
+  </dd>
+  <dt class="changed"><dfn data-cite="JSON-LD11-API#dfn-iri-expanding">IRI expanding</dfn></dt>
+  <dd class="algorithm changed">
+    Used as a macro within various algorithms as to reduce the language used to describe
+    the process of expanding a <a>string</a> <var>value</var> representing an <a>IRI</a> or <a>keyword</a>
+    using an <var>active context</var> either specified directly, or coming from the scope of
+    the algorithm step using this term.
+    Optional <var>defined</var> and <var>local context</var> arguments are used, if explicitly provided.
+    Unless specified,
+    the <var>document relative</var> flag defaults to `false`,
+    and the <var>vocab</var> flag defaults to `true`.
+    <ol>
+      <li>Return the result of using the <a href="#iri-expansion">IRI Expansion algorithm</a>,
+        passing <var>active context</var>,
+        <var>value</var>,
+        <var>local context</var> (if supplied),
+        <var>defined</var> (if supplied),
+        <var>document relative</var>,
+        and <var>vocab</var>.</li>
+    </ol>
+  </dd>
   <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-input-frame">input frame</dfn></dt><dd>
     The initial <a>Frame</a> provided to the framing algorithm.</dd>
   <dt><dfn data-cite="JSON-LD11-API#dfn-json-ld-input">JSON-LD input</dfn></dt><dd>

--- a/index.html
+++ b/index.html
@@ -12391,6 +12391,9 @@ the data type to be specified explicitly with each piece of data.</p>
     <p>If the <a>expanded term definition</a> contains the <code>@language</code> <a>keyword</a>,
       its value MUST have the <a data-cite="BCP47#section-2.1.1">lexical form</a> described in [[BCP47]] or be <a>null</a>.</p>
 
+    <p class="changed">If the <a>expanded term definition</a> contains the `@index`
+      <a>keyword</a>, its value MUST be <code>true</code> or <code>false</code>.</p>
+
     <p>If the <a>expanded term definition</a> contains the <code>@container</code>
       <a>keyword</a>, its value MUST be either
       <code>@list</code>,
@@ -12521,8 +12524,10 @@ the data type to be specified explicitly with each piece of data.</p>
       The <code>@index</code> keyword MAY be aliased and MAY be used as a key in a
       <a>node object</a>, <a>value object</a>, <a>graph object</a>, <a>set object</a>, or <a>list object</a>.
       Its value MUST be a <a>string</a>.
-      <p>The unaliased <code>@index</code> MAY be used as the value of the <code>@container</code> key within an <a>expanded term definition</a>.</p>
-      <p>See <a class="sectionRef" href="#index-maps"></a> for a further discussion.</p>
+      <p>The unaliased <code>@index</code> MAY be used as the value of the <code>@container</code> key within an <a>expanded term definition</a>
+        and as an entry in a <a>expanded term definition</a>, where the value is `true` or `false`.</p>
+      <p>See <a class="sectionRef" href="#index-maps"></a>, and
+        <a class="sectionRef" href="#property-based-data-indexing"></a> for a further discussion.</p>
     </dd>
     <dt><code>@language</code></dt><dd>
       The <code>@language</code> keyword MAY be aliased and MAY be used as a key in a <a>value object</a>.

--- a/index.html
+++ b/index.html
@@ -12392,7 +12392,8 @@ the data type to be specified explicitly with each piece of data.</p>
       its value MUST have the <a data-cite="BCP47#section-2.1.1">lexical form</a> described in [[BCP47]] or be <a>null</a>.</p>
 
     <p class="changed">If the <a>expanded term definition</a> contains the `@index`
-      <a>keyword</a>, its value MUST be <code>true</code> or <code>false</code>.</p>
+      <a>keyword</a>, its value MUST be an <a>IRI</a>,
+      a <a>compact IRI</a>, or a <a>term</a>.</p>
 
     <p>If the <a>expanded term definition</a> contains the <code>@container</code>
       <a>keyword</a>, its value MUST be either
@@ -12525,7 +12526,8 @@ the data type to be specified explicitly with each piece of data.</p>
       <a>node object</a>, <a>value object</a>, <a>graph object</a>, <a>set object</a>, or <a>list object</a>.
       Its value MUST be a <a>string</a>.
       <p>The unaliased <code>@index</code> MAY be used as the value of the <code>@container</code> key within an <a>expanded term definition</a>
-        and as an entry in a <a>expanded term definition</a>, where the value is `true` or `false`.</p>
+        and as an entry in a <a>expanded term definition</a>, where the value an <a>IRI</a>,
+        a <a>compact IRI</a>, or a <a>term</a>.</p>
       <p>See <a class="sectionRef" href="#index-maps"></a>, and
         <a class="sectionRef" href="#property-based-data-indexing"></a> for a further discussion.</p>
     </dd>

--- a/index.html
+++ b/index.html
@@ -13708,16 +13708,11 @@ the data type to be specified explicitly with each piece of data.</p>
     <li>Warn about forward-compatibility issues for terms of the form (`"@"1*ALPHA`).</li>
   </ul>
 </section>
-<section class="appendix informative" id="changes-from-cr">
+<!--section class="appendix informative" id="changes-from-cr">
   <h2>Changes since Candidate Release of 12 December 2019</h2>
   <ul>
-    <li>Added a <a href="#issue318">Note</a> motivating the lack of native support
-      for `xsd:decimal` literals.
-      This is in response to <a href="https://github.com/w3c/json-ld-syntax/issues/318">Issue 318</a>.</li>
-    <li>Updated section number references into [[ECMASCRIPT]] within <a href="#the-rdf-json-datatype" class="sectionRef"></a>.
-      This is in response to <a href="https://github.com/w3c/json-ld-syntax/issues/321">Issue 321</a>.</li>
   </ul>
-</section>
+</section-->
 
 <section id="ack"
          class="appendix informative"


### PR DESCRIPTION
* Add missing description of using `@index` in an expanded term definition. Fixes #324.
* Comment out and clear Changes since CR section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/326.html" title="Last updated on Jan 28, 2020, 9:27 PM UTC (8d3d281)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/326/f55efdc...8d3d281.html" title="Last updated on Jan 28, 2020, 9:27 PM UTC (8d3d281)">Diff</a>