### PR TITLE
Update description of i18n datatype

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: git://github.com/ruby-rdf/json-ld.git
-  revision: d0bfdefb6cddac6a22683ff9733a94936c4e5dbe
+  revision: 241ef57e096cefdff55ef6d39a917049eec04529
   branch: develop
   specs:
     json-ld (3.1.0)
       htmlentities (~> 4.3)
-      json-canonicalization (~> 0.1)
+      json-canonicalization (~> 0.2)
       link_header (~> 0.0, >= 0.0.8)
       multi_json (~> 1.14)
       rack (~> 2.0)
@@ -19,7 +19,7 @@ GEM
     bcp47 (0.3.3)
       i18n
     builder (3.2.4)
-    byebug (11.0.1)
+    byebug (11.1.1)
     colorize (0.8.1)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
@@ -34,9 +34,9 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     htmlentities (4.3.4)
-    i18n (1.7.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
-    json-canonicalization (0.1.0)
+    json-canonicalization (0.2.0)
     json-ld-preloaded (3.1.0)
       json-ld (~> 3.1)
       rdf (~> 3.1)
@@ -80,10 +80,10 @@ GEM
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.2)
       nokogiri (~> 1.8, >= 1.8.4)
-    public_suffix (4.0.1)
-    rack (2.0.8)
+    public_suffix (4.0.3)
+    rack (2.1.2)
     rake (13.0.1)
-    rdf (3.1.0)
+    rdf (3.1.1)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
     rdf-aggregate-repo (3.1.0)
@@ -134,7 +134,7 @@ GEM
     rdf-turtle (3.1.0)
       ebnf (~> 1.2)
       rdf (~> 3.1)
-    rdf-vocab (3.1.0)
+    rdf-vocab (3.1.1)
       rdf (~> 3.1)
     rdf-xsd (3.1.0)
       rdf (~> 3.1)

--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -9,6 +9,27 @@
     which is used for finding coercion mappings in the <a>active context</a>.</dd>
   <dt><dfn data-cite="JSON-LD11-API#dfn-active-subject">active subject</dfn></dt><dd>
     The currently active subject that the processor should use when processing.</dd>
+  <dt class="changed"><dfn data-cite="JSON-LD11-API#add-value">add value</dfn></dt>
+  <dd class="algorithm changed">
+    Used as a macro within various algorithms as a way to add a <var>value</var>
+    to an <a>entry</a> in a <a>map</a> (<var>object</var>) using a specified <var>key</var>.
+    The invocation may include an <var>as array</var> flag defaulting to <code>false</code>.
+    <ol>
+      <li>If <var>as array</var> is <code>true</code>,
+        and <var>value</var> is not an <a>array</a>,
+        set it to an <a>array</a> containing <var>value</var>.</li>
+      <li>If <var>key</var> is not an entry in <var>object</var>,
+        add <var>value</var> as the value of <var>key</var> in <var>object</var>.</li>
+      <li>Otherwise
+        <ol>
+          <li>If the value of <var>key</var> <a>entry</a> in <var>object</var> is not an <a>array</a>,
+            set it to a new <a>array</a> containing the original value.</li>
+          <li>If <var>value</var> is an <a>array</a>, concatenate <var>value</var>
+            to that <a>entry</a>.</li>
+          <li>Otherwise, append <var>value</var> to that <a>entry</a>.</li>
+        </ol>
+    </ol>
+  </dd>
   <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-expicit-inclusion-flag">explicit inclusion flag</dfn></dt><dd>
     A flag specifying that for <a>properties</a> to be included in the output,
     they must be explicitly declared in the matching <a>frame</a>.</dd>
@@ -20,6 +41,46 @@
     used internally to help determine if object embedding is appropriate,</span>
     the <a>explicit inclusion flag</a>,
     and the <a>omit default flag</a>.</dd>
+  <dt class="changed"><dfn data-cite="JSON-LD11-API#dfn-iri-compacting">IRI compacting</dfn></dt>
+  <dd class="algorithm changed">
+    Used as a macro within various algorithms as to reduce the language used to describe
+    the process of compacting a <a>string</a> <var>var</var> representing an <a>IRI</a> or <a>keyword</a>
+    using an <var>active context</var> either specified directly, or coming from the scope of
+    the algorithm step using this term and <var>inverse context</var> also taken
+    from the scope of the algorithm step using this term.
+    An optional <var>value</var> is used, if explicitly provided.
+    Unless specified,
+    the <var>vocab</var> flag defaults to `true`,
+    and the <var>reverse</var> flag defaults to `false`.
+    <ol>
+      <li>Return the result of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
+        passing <var>active context</var>, <var>inverse context</var>,
+        <var>var</var>,
+        <var>value</var> (if supplied),
+        <var>vocab</var>,
+        and <var>result</var>.</li>
+    </ol>
+  </dd>
+  <dt class="changed"><dfn data-cite="JSON-LD11-API#dfn-iri-expanding">IRI expanding</dfn></dt>
+  <dd class="algorithm changed">
+    Used as a macro within various algorithms as to reduce the language used to describe
+    the process of expanding a <a>string</a> <var>value</var> representing an <a>IRI</a> or <a>keyword</a>
+    using an <var>active context</var> either specified directly, or coming from the scope of
+    the algorithm step using this term.
+    Optional <var>defined</var> and <var>local context</var> arguments are used, if explicitly provided.
+    Unless specified,
+    the <var>document relative</var> flag defaults to `false`,
+    and the <var>vocab</var> flag defaults to `true`.
+    <ol>
+      <li>Return the result of using the <a href="#iri-expansion">IRI Expansion algorithm</a>,
+        passing <var>active context</var>,
+        <var>value</var>,
+        <var>local context</var> (if supplied),
+        <var>defined</var> (if supplied),
+        <var>document relative</var>,
+        and <var>vocab</var>.</li>
+    </ol>
+  </dd>
   <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-input-frame">input frame</dfn></dt><dd>
     The initial <a>Frame</a> provided to the framing algorithm.</dd>
   <dt><dfn data-cite="JSON-LD11-API#dfn-json-ld-input">JSON-LD input</dfn></dt><dd>

--- a/index.html
+++ b/index.html
@@ -12913,10 +12913,13 @@ the data type to be specified explicitly with each piece of data.</p>
     <p>The <a data-cite="JSON-LD11-API#deserialize-json-ld-to-rdf-algorithm">Deserialize JSON-LD to RDF Algorithm</a>
       can be used with the <dfn data-cite="JSON-LD11-API#dom-jsonldoptions-rdfdirection">rdfDirection</dfn> option
       set to `i18n-datatype` to generate <a>RDF literals</a> using the `i18n` base to create an IRI
-      encoding the <a>base direction</a> along with optional <a>language tag</a> from
-      value objects containing `@direction` by appending to `https://www.w3.org/ns/i18n#`
+      encoding the <a>base direction</a> along with optional <a>language tag</a> (normalized to lower case)
+      from value objects containing `@direction` by appending to `https://www.w3.org/ns/i18n#`
       the value of `@language`, if any, followed by an underscore (`"_"`) followed
       by the value of `@direction`.</p>
+
+    <p>For improved interoperability, the <a>language tag</a> is normalized to
+      lower case when creating the datatype IRI.</p>
 
     <p class="issue atrisk">This feature is experimental, as RDF does not have a
       standard way to represent base direction in <a>RDF literals</a>.
@@ -12937,8 +12940,8 @@ the data type to be specified explicitly with each piece of data.</p>
 
     # Note that this version preserves the base direction using a non-standard datatype.
     [
-      ex:title ****"HTML و CSS: تصميم و إنشاء مواقع الويب"^^i18n:ar-EG_rtl****;
-      ex:publisher ****"مكتبة"^^i18n:ar-EG_rtl****
+      ex:title ****"HTML و CSS: تصميم و إنشاء مواقع الويب"^^i18n:ar-eg_rtl****;
+      ex:publisher ****"مكتبة"^^i18n:ar-eg_rtl****
     ] .
     -->
     </pre>
@@ -12968,8 +12971,11 @@ the data type to be specified explicitly with each piece of data.</p>
     <p>The <a data-cite="JSON-LD11-API#deserialize-json-ld-to-rdf-algorithm">Deserialize JSON-LD to RDF Algorithm</a>
       can be used with the <a>rdfDirection</a> option
       set to `compound-literal` to generate <a>RDF literals</a> using these properties to
-      describe the <a>base direction</a> and optional <a>language tag</a> from
-      value objects containing `@direction` and optionally `@language`.</p>
+      describe the <a>base direction</a> and optional <a>language tag</a> (normalized to lower case)
+      from value objects containing `@direction` and optionally `@language`.</p>
+
+    <p>For improved interoperability, the <a>language tag</a> is normalized to
+      lower case when creating the datatype IRI.</p>
 
     <p class="issue atrisk">This feature is experimental, as RDF does not have a
       standard way to represent base direction in <a>RDF literals</a>.
@@ -12991,12 +12997,12 @@ the data type to be specified explicitly with each piece of data.</p>
     [
       ex:title ****[
         rdf:value "HTML و CSS: تصميم و إنشاء مواقع الويب",
-        rdf:language "ar-EG",
+        rdf:language "ar-eg",
         rdf:direction "rtl"
       ]****;
       ex:publisher ****[
         rdf:value "مكتبة",
-        rdf:language "ar-EG",
+        rdf:language "ar-eg",
         rdf:direction "rtl"
       ]****
     ] .
@@ -13701,6 +13707,8 @@ the data type to be specified explicitly with each piece of data.</p>
     <li>Allow further structured subtypes of `application/ld+json` by using
       `+ld+json` as a suffix for a new base type.</li>
     <li>Warn about forward-compatibility issues for terms of the form (`"@"1*ALPHA`).</li>
+    <li>When creating an `i18n` datatype or `rdf:CompoundLiteral`, <a>language tags</a> are
+      normalized to lower case to improve interoperability between implementations.</li>
   </ul>
 </section>
 <section class="appendix informative" id="changes-from-cr">


### PR DESCRIPTION
and Compound Literal to lower case language tags.

For w3c/json-ld-api#337.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/327.html" title="Last updated on Jan 29, 2020, 6:05 PM UTC (ea2bc38)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/327/f55efdc...ea2bc38.html" title="Last updated on Jan 29, 2020, 6:05 PM UTC (ea2bc38)">Diff</a>