### PR TITLE
Comment out `+ld+json` mime extensions.

### DIFF
--- a/index.html
+++ b/index.html
@@ -13467,11 +13467,11 @@ the data type to be specified explicitly with each piece of data.</p>
           </dl>
           <p>All other URIs starting with <code>http://www.w3.org/ns/json-ld</code>
             are reserved for future use by JSON-LD specifications.</p>
-          <p>Other specifications MAY create further structured subtypes
+          <!--p>Other specifications MAY create further structured subtypes
             by using `+ld+json` as a suffix for a new base subtype, as in
             `application/example+ld+json`.
             Unless defined otherwise, such subtypes use the same
-            fragment identifier behavior as `application/ld+json`.</p>
+            fragment identifier behavior as `application/ld+json`.</p-->
           <p>Other specifications may publish additional `profile` parameter
             URIs with their own defined semantics.
             This includes the ability to associate a file extension with a `profile` parameter.</p>
@@ -13711,8 +13711,8 @@ the data type to be specified explicitly with each piece of data.</p>
     <li>The <a>processing mode</a> is now implicitly `json-ld-1.1`, unless set
       explicitly to `json-ld-1.0`.</li>
     <li>Improve notation using <a>IRI</a>, <a>IRI reference</a>, and <a>relative IRI reference</a>.</li>
-    <li>Allow further structured subtypes of `application/ld+json` by using
-      `+ld+json` as a suffix for a new base type.</li>
+    <!--li>Allow further structured subtypes of `application/ld+json` by using
+      `+ld+json` as a suffix for a new base type.</li-->
     <li>Warn about forward-compatibility issues for terms of the form (`"@"1*ALPHA`).</li>
     <li>When creating an `i18n` datatype or `rdf:CompoundLiteral`, <a>language tags</a> are
       normalized to lower case to improve interoperability between implementations.</li>


### PR DESCRIPTION
See https://lists.w3.org/Archives/Public/public-json-ld-wg/2020Feb/0024.html.

> It seems that the *+ld+json is an issue for IETF and cannot be done.

> I think that, at this point, we should remove this thing from the JSON-LD spec and finalize the spec with ld+json. I do not think we should make the progress towards a Rec stop because of that.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/331.html" title="Last updated on Feb 22, 2020, 1:47 AM UTC (7e1ee2d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/331/17dd029...7e1ee2d.html" title="Last updated on Feb 22, 2020, 1:47 AM UTC (7e1ee2d)">Diff</a>