### PR TITLE
Update normative reference for _vocabulary mapping_ term

### DIFF
--- a/common/terms.html
+++ b/common/terms.html
@@ -391,11 +391,11 @@
     and a type,
     which is an <a>IRI</a>.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-value-object">value object</dfn></dt><dd>
-    A <a>value object</a> is a <a>map</a> that has an <code>@value</code> <a>entry</a>.</dd>
+    A <a>value object</a> is a <a>map</a> that has an <code>@value</code> <a>entry</a>.
+    See the <a data-cite="JSON-LD11#value-objects">Value Objects</a> section of JSON-LD 1.1 for a normative description.</dd>
   <dt><dfn data-cite="JSON-LD11#dfn-vocabulary-mapping" class="preserve">vocabulary mapping</dfn></dt><dd>
     The vocabulary mapping is set in the <a>context</a> using the <code>@vocab</code> key
     whose value must be an <a>IRI</a>, a <a>compact IRI</a>, a <a>term</a>, or <code>null</code>.
-    See the <a data-cite="JSON-LD11#value-objects">Value Objects</a> section of JSON-LD 1.1 for a normative description.
-  </dd>
+    See the <a data-cite="JSON-LD11#context-definitions">Context Definitions</a> section of JSON-LD 1.1 for a normative description.</dd>
 </dl>
 </section>


### PR DESCRIPTION
…to point to Contexts Definitions.

Move reference to Value Objects up to the _value object_ term.

Fixes #341.