### PR TITLE
Added a note on superseding 1.0 into the SOTD

### DIFF
--- a/index.html
+++ b/index.html
@@ -318,6 +318,8 @@
     <a href="https://json-ld.org/playground/">live JSON-LD playground</a> that is capable
     of demonstrating the features described in this document.</p>
 
+  <p>This specification is intended to <a href='https://www.w3.org/2019/Process-20190301/#rec-rescind'>supersede</a> [[[JSON-LD10]]] [[JSON-LD10]]. </p>
+
   <section>
     <h2>Set of Documents</h2>
     <p>This document is one of three JSON-LD 1.1 Recommendations produced by the

--- a/index.html
+++ b/index.html
@@ -318,7 +318,7 @@
     <a href="https://json-ld.org/playground/">live JSON-LD playground</a> that is capable
     of demonstrating the features described in this document.</p>
 
-  <p>This specification is intended to <a href='https://www.w3.org/2019/Process-20190301/#rec-rescind'>supersede</a> [[[JSON-LD10]]] [[JSON-LD10]]. </p>
+  <p>This specification is intended to <a href='https://www.w3.org/2019/Process-20190301/#rec-rescind'>supersede</a> the [[[JSON-LD10]]] [[JSON-LD10]] specification. </p>
 
   <section>
     <h2>Set of Documents</h2>

--- a/publication-snapshots/PR/Overview.html
+++ b/publication-snapshots/PR/Overview.html
@@ -1347,6 +1347,8 @@
     <a href="https://json-ld.org/playground/">live JSON-LD playground</a> that is capable
     of demonstrating the features described in this document.</p>
 
+  <p>This specification is intended to <a href="https://www.w3.org/2019/Process-20190301/#rec-rescind">supersede</a> the <cite><a href="https://www.w3.org/TR/2014/REC-json-ld-20140116/">JSON-LD 1.0</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld10" title="JSON-LD 1.0">JSON-LD10</a></cite>] specification. </p>
+
   <p>
     This document was published by the <a href="https://www.w3.org/2018/json-ld-wg/">JSON-LD Working Group</a> as a
     Proposed Recommendation.


### PR DESCRIPTION
At the instruction of PlH I have added a note into the SOTD about this. To make things quicker and avoid problems, I have changed the version of the document already on /TR.





(Oops, I realized I made a spelling mistake in the name of the branch:-)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/350.html" title="Last updated on May 6, 2020, 7:29 PM UTC (0a27e4c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/350/6c4be3d...0a27e4c.html" title="Last updated on May 6, 2020, 7:29 PM UTC (0a27e4c)">Diff</a>