### PR TITLE
Remove atrisk notes.

### DIFF
--- a/index.html
+++ b/index.html
@@ -12940,12 +12940,6 @@ the data type to be specified explicitly with each piece of data.</p>
     <p>For improved interoperability, the <a>language tag</a> is normalized to
       lower case when creating the datatype IRI.</p>
 
-    <p class="issue atrisk">This feature is experimental, as RDF does not have a
-      standard way to represent base direction in <a>RDF literals</a>.
-      A future RDF Working Group may support base direction differently.
-      The JSON-LD Working Group solicits feedback from the community on the
-      usefulness of these transformations.</p>
-
     <p>The following example shows two statements with literal values of `i18n:ar-EG_rtl`,
       which encodes the language tag `ar-EG` and the base direction `rtl`.</p>
     <pre class="turtle-dt nohighlight"
@@ -12995,12 +12989,6 @@ the data type to be specified explicitly with each piece of data.</p>
 
     <p>For improved interoperability, the <a>language tag</a> is normalized to
       lower case when creating the datatype IRI.</p>
-
-    <p class="issue atrisk">This feature is experimental, as RDF does not have a
-      standard way to represent base direction in <a>RDF literals</a>.
-      A future RDF Working Group may support base direction differently.
-      The JSON-LD Working Group solicits feedback from the community on the
-      usefulness of these transformations.</p>
 
     <p>The following example shows two statements with compound literals
       representing strings with the <a>language tag</a> `ar-EG` and <a>base direction</a> `rtl`.</p>


### PR DESCRIPTION
For w3c/json-ld-wg#150.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/354.html" title="Last updated on Jun 8, 2020, 12:43 AM UTC (37b1641)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/354/4c103ea...37b1641.html" title="Last updated on Jun 8, 2020, 12:43 AM UTC (37b1641)">Diff</a>