### PR TITLE
Change JCS bibref to RFC8785, as it's now published.

### DIFF
--- a/common/jsonld.js
+++ b/common/jsonld.js
@@ -59,11 +59,11 @@ const jsonld = {
       status: 'unofficial',
       date: '29 May 2015'
     },
-    "JCS": {
+    "RFC8785": {
       title: "JSON Canonicalization Scheme (JCS)",
-      href: 'https://tools.ietf.org/html/draft-rundgren-json-canonicalization-scheme-17',
+      href: 'https://www.rfc-editor.org/rfc/rfc8785',
       authors: ['A. Rundgren', 'B. Jordan', 'S. Erdtman'],
-      publisher: 'Network Working Group',
+      publisher: 'Informational',
       status: 'Internet-Draft',
       date: '20 January 2020'
     },

--- a/common/jsonld.js
+++ b/common/jsonld.js
@@ -63,9 +63,9 @@ const jsonld = {
       title: "JSON Canonicalization Scheme (JCS)",
       href: 'https://www.rfc-editor.org/rfc/rfc8785',
       authors: ['A. Rundgren', 'B. Jordan', 'S. Erdtman'],
-      publisher: 'Informational',
-      status: 'Internet-Draft',
-      date: '20 January 2020'
+      publisher: 'Network Working Group',
+      status: 'Informational',
+      date: 'June 2020'
     },
     // These necessary as specref uses the wrong URLs
     "RFC7231": {

--- a/index.html
+++ b/index.html
@@ -12894,9 +12894,8 @@ the data type to be specified explicitly with each piece of data.</p>
             <code>U+005C</code> (<code>\</code>) and <code>U+0022</code> (<code>"</code>)
             which SHOULD be serialized as <code>\\</code> and <code>\"</code> respectively.</li>
         </ul>
-        <div class="issue changed">The JSON Canonicalization Scheme [[?JCS]]
-          is an emerging standard for JSON canonicalization
-          not yet ready to be referenced.
+        <div class="issue changed">The JSON Canonicalization Scheme [[RFC8785]]
+          is a standard for JSON canonicalization.
           When a JSON canonicalization standard becomes available,
           this specification will likely be updated to require such a canonical representation.
           Users are cautioned from depending on the

--- a/index.html
+++ b/index.html
@@ -12894,10 +12894,9 @@ the data type to be specified explicitly with each piece of data.</p>
             <code>U+005C</code> (<code>\</code>) and <code>U+0022</code> (<code>"</code>)
             which SHOULD be serialized as <code>\\</code> and <code>\"</code> respectively.</li>
         </ul>
-        <div class="issue changed">The JSON Canonicalization Scheme [[RFC8785]]
+        <div class="issue changed">The JSON Canonicalization Scheme (JCS) [[RFC8785]]
           is a standard for JSON canonicalization.
-          When a JSON canonicalization standard becomes available,
-          this specification will likely be updated to require such a canonical representation.
+          This specification will likely be updated to require such a canonical representation.
           Users are cautioned from depending on the
           <a>JSON literal</a> lexical representation as an <a>RDF literal</a>,
           as the specifics of serialization may change in a future revision of this document.</div>
@@ -13738,6 +13737,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <li>Updated the non-normative definitions of the `i18n` based datatype in <a href="#the-i18n-namespace" class="sectionRef"></a>
       and `rdf:CompoundLiteral` class in <a href="#the-rdf-compoundliteral-class-and-the-rdf-language-and-rdf-direction-properties" class="sectionRef"></a>
       to normalize language tags to lowercase when generating RDF.</li>
+    <li>Update bibliographic reference for JCS to [[RFC8785]].</li>
   </ul>
 </section>
 


### PR DESCRIPTION
Note that we discuss changing our canonicalization requirements to JCS when it becomes available, which it is now. Perhaps something to take up post-publication.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/357.html" title="Last updated on Jun 30, 2020, 10:25 PM UTC (d1e4f98)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/357/f22165c...d1e4f98.html" title="Last updated on Jun 30, 2020, 10:25 PM UTC (d1e4f98)">Diff</a>