### PR TITLE
Updates to accommodate ReSpec changes and subsequent issues found post-REC.

### DIFF
--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -38,7 +38,7 @@
       </li>
     </ol>
   </dd>
-  <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-expicit-inclusion-flag">explicit inclusion flag</dfn></dt><dd>
+  <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-explicit-inclusion-flag">explicit inclusion flag</dfn></dt><dd>
     A flag specifying that for <a>properties</a> to be included in the output,
     they must be explicitly declared in the matching <a>frame</a>.</dd>
   <dt><dfn data-cite="JSON-LD11-FRAMING#dfn-framing-state">framing state</dfn></dt><dd>
@@ -78,7 +78,7 @@
     the <var>document relative</var> flag defaults to `false`,
     and the <var>vocab</var> flag defaults to `true`.
     <ol>
-      <li>Return the result of using the <a href="#iri-expansion">IRI Expansion algorithm</a>,
+      <li>Return the result of using the <a data-cite="JSON-LD11-API#iri-expansion">IRI Expansion algorithm</a>,
         passing <var>active context</var>,
         <var>value</var>,
         <var>local context</var> (if supplied),

--- a/common/algorithm-terms.html
+++ b/common/algorithm-terms.html
@@ -9,7 +9,7 @@
     which is used for finding coercion mappings in the <a>active context</a>.</dd>
   <dt><dfn data-cite="JSON-LD11-API#dfn-active-subject">active subject</dfn></dt><dd>
     The currently active subject that the processor should use when processing.</dd>
-  <dt class="changed"><dfn data-cite="JSON-LD11-API#add-value">add value</dfn></dt>
+  <dt class="changed"><dfn data-cite="JSON-LD11-API#dfn-add-value">add value</dfn></dt>
   <dd class="algorithm changed">
     Used as a macro within various algorithms as a way to add a <var>value</var>
     to an <a>entry</a> in a <a>map</a> (<var>object</var>) using a specified <var>key</var>.

--- a/common/terms.html
+++ b/common/terms.html
@@ -188,7 +188,7 @@
     An embedded <a>context</a> is a context which appears
     as the <code>@context</code> <a>entry</a> of one of the following:
     a <a>node object</a>, a <a>value object</a>, a <a>graph object</a>, a <a>list object</a>,
-    a <a>set object</a>, the value of a <a>nested properties</a>,
+    a <a>set object</a>, the value of a <a>nested property</a>,
     or the value of an <a>expanded term definition</a>.
     Its value may be a <a>map</a> for a <a data-cite="JSON-LD11#dfn-context-definition">context definition</a>,
     as an <a>IRI</a>, or as an <a>array</a> combining either of the above.
@@ -230,7 +230,7 @@
     Note that <a>node objects</a> may have a <code>@graph</code> <a>entry</a>,
     but are not considered <a>graph objects</a> if they include any other <a>entries</a>.
     A top-level object consisting of <code>@graph</code> is also not a <a>graph object</a>.
-    Note that a <a>node object</a> may also represent a <a>named graph</a> it it includes other properties.
+    Note that a <a>node object</a> may also represent a <a>named graph</a> if it includes other properties.
     See the <a data-cite="JSON-LD11#graph-objects">Graph Objects</a> section of JSON-LD 1.1 for a normative description.
   </dd>
   <dt class="changed"><dfn data-cite="JSON-LD11#dfn-id-map">id map</dfn></dt><dd class="changed">
@@ -302,7 +302,7 @@
     and normatively specified in the <a data-cite="JSON-LD11#keywords">Keywords</a> section of JSON-LD 1.1,
   </dd>
   <dt><dfn data-cite="JSON-LD11#dfn-language-map">language map</dfn></dt><dd>
-    An <a>language map</a> is a <a>map</a> value of a <a>term</a>
+    A <a>language map</a> is a <a>map</a> value of a <a>term</a>
     defined with <code>@container</code> set to <code>@language</code>,
     whose keys must be <a>strings</a> representing [[BCP47]] language codes
     and the values must be any of the following types:

--- a/common/typographical-conventions.html
+++ b/common/typographical-conventions.html
@@ -15,7 +15,7 @@
     A reference to a definition <em>in this document</em>
     is underlined and is also an active link to the definition itself. </dd>
   <dt><a data-lt="definition"><code>markup definition reference</code></a></dt><dd>
-    A references to a definition <em>in this document</em>,
+    References to a definition <em>in this document</em>,
     when the reference itself is also a markup, is underlined,
     red-orange monospace font, and is also an active link to the definition itself.</dd>
   <dt><a class="externalDFN">external definition reference</a></dt><dd>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <title>JSON-LD 1.1</title>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
-<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer></script>
+<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
 <script src="common/common.js" class="remove" defer></script>
 <script src="common/jsonld.js" class="remove"></script>
 <script class="remove">
@@ -800,7 +800,7 @@
       <button class="selected" data-selects="expanded">Expanded (Input)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle (Result)</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="expanded input selected nohighlight" data-transform="updateExample">
     <!--
@@ -941,7 +941,7 @@
         <button data-selects="expanded">Expanded (Result)</button>
         <button data-selects="statements">Statements</button>
         <button data-selects="turtle">Turtle</button>
-        <a class="playground" target="_blank"></a>
+        <a class="playground" target="_blank" href="#">PGPG</a>
       </div>
       <pre class="compacted input selected nohighlight" data-transform="updateExample">
       <!--
@@ -1048,7 +1048,7 @@
         <button data-selects="expanded">Expanded (Result)</button>
         <button data-selects="statements">Statements</button>
         <button data-selects="turtle">Turtle</button>
-        <a class="playground" target="_blank"></a>
+        <a class="playground" target="_blank" href="#">PGPG</a>
       </div>
       <pre class="compacted input selected input nohighlight" data-transform="updateExample">
       <!--
@@ -1205,7 +1205,7 @@
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -1263,7 +1263,7 @@
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -1363,7 +1363,7 @@
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -1532,7 +1532,7 @@
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -1596,7 +1596,7 @@
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -1653,7 +1653,7 @@
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -1755,7 +1755,7 @@
         <button data-selects="expanded">Expanded (Result)</button>
         <button data-selects="statements">Statements</button>
         <button data-selects="turtle">Turtle</button>
-        <a class="playground" target="_blank"></a>
+        <a class="playground" target="_blank" href="#">PGPG</a>
       </div>
       <pre class="compacted input selected nohighlight" data-transform="updateExample">
       <!--
@@ -1825,7 +1825,7 @@
         <button data-selects="expanded">Expanded (Result)</button>
         <button data-selects="statements">Statements</button>
         <button data-selects="turtle">Turtle</button>
-        <a class="playground" target="_blank"></a>
+        <a class="playground" target="_blank" href="#">PGPG</a>
       </div>
       <pre class="compacted input selected nohighlight" data-transform="updateExample"
            title="Embedding Objects">
@@ -1926,7 +1926,7 @@
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -2034,7 +2034,7 @@
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -2139,7 +2139,7 @@
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -2240,7 +2240,7 @@
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -2367,7 +2367,7 @@
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -2429,7 +2429,7 @@
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -2495,7 +2495,7 @@
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -2589,7 +2589,7 @@
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -2679,7 +2679,7 @@
     <button class="selected" data-selects="expanded">Expanded (Result)</button>
     <button data-selects="statements">Statements</button>
     <button data-selects="turtle">Turtle</button>
-    <a class="playground" target="_blank"></a>
+    <a class="playground" target="_blank" href="#">PGPG</a>
   </div>
   <pre class="expanded result selected nohighlight" data-transform="updateExample">
   <!--
@@ -2734,7 +2734,7 @@
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -2811,7 +2811,7 @@
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -2944,7 +2944,8 @@
          data-result-for="#term-selection-example"
          data-context="#term-selection-context-0"
          data-compact
-         target="_blank"></a>
+         target="_blank"
+         href="#">PGPG</a>
     </div>
     <pre class="compacted result selected nohighlight"
          data-transform="updateExample"
@@ -3018,7 +3019,8 @@
          data-result-for="#term-selection-example"
          data-context="#term-selection-context-1"
          data-compact
-         target="_blank"></a>
+         target="_blank"
+         href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample"
          data-result-for="Expanded document used to illustrate compact IRI creation"
@@ -3085,7 +3087,7 @@
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -3360,7 +3362,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -3444,7 +3446,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -3663,7 +3665,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -3959,7 +3961,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
         <button data-selects="expanded">Expanded (Result)</button>
         <button data-selects="statements">Statements</button>
         <button data-selects="turtle">Turtle</button>
-        <a class="playground" target="_blank"></a>
+        <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
       <!--
@@ -4058,7 +4060,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
         <button data-selects="expanded">Expanded</button>
         <button data-selects="statements">Statements</button>
         <button data-selects="turtle">Turtle</button>
-        <a class="playground" target="_blank"></a>
+        <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="original selected nohighlight" data-transform="updateExample" data-ignore>
       <!--
@@ -4165,7 +4167,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
         <button data-selects="expanded">Expanded (Result)</button>
         <button data-selects="statements">Statements</button>
         <button data-selects="turtle">Turtle</button>
-        <a class="playground" target="_blank"></a>
+        <a class="playground" target="_blank" href="#">PGPG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
       <!--
@@ -4305,7 +4307,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     <button data-selects="expanded">Expanded (Result)</button>
     <button data-selects="statements">Statements</button>
     <button data-selects="turtle">Turtle</button>
-    <a class="playground" target="_blank"></a>
+    <a class="playground" target="_blank" href="#">PGPG</a>
   </div>
   <pre class="compacted input selected nohighlight" data-transform="updateExample">
   <!--
@@ -4374,7 +4376,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     <button data-selects="expanded">Expanded (Result)</button>
     <button data-selects="statements">Statements</button>
     <button data-selects="turtle">Turtle</button>
-    <a class="playground" target="_blank"></a>
+    <a class="playground" target="_blank" href="#">PGPG</a>
   </div>
   <pre class="compacted input selected nohighlight" data-transform="updateExample">
   <!--
@@ -4486,7 +4488,8 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     <button class="selected" data-selects="compacted">Compacted (Input)</button>
     <button data-selects="turtle">Turtle</button>
     <a class="playground" target="_blank"
-       data-result-for="#context-sensitivity-for-type"></a>
+       data-result-for="#context-sensitivity-for-type"
+       href="#">PGPG</a>
   </div>
   <table class="compacted input selected"
        data-result-for="Example demonstrating the context-sensitivity for @type"
@@ -4564,7 +4567,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     <button data-selects="expanded">Expanded (Result)</button>
     <button data-selects="statements">Statements</button>
     <button data-selects="turtle">Turtle</button>
-    <a class="playground" target="_blank"></a>
+    <a class="playground" target="_blank" href="#">PGPG</a>
   </div>
   <pre class="compacted input selected nohighlight" data-transform="updateExample">
   <!--
@@ -4684,7 +4687,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <button data-selects="expanded">Expanded (Result)</button>
     <button data-selects="statements">Statements</button>
     <button data-selects="turtle">Turtle</button>
-    <a class="playground" target="_blank"></a>
+    <a class="playground" target="_blank" href="#">PGPG</a>
   </div>
   <pre class="compacted input selected nohighlight" data-transform="updateExample">
   <!--
@@ -4796,7 +4799,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <button data-selects="expanded">Expanded (Result)</button>
     <button data-selects="statements">Statements</button>
     <button data-selects="turtle">Turtle</button>
-    <a class="playground" target="_blank"></a>
+    <a class="playground" target="_blank" href="#">PGPG</a>
   </div>
   <pre class="compacted input selected nohighlight" data-transform="updateExample">
   <!--
@@ -4881,7 +4884,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <button data-selects="expanded">Expanded (Result)</button>
     <button data-selects="statements">Statements</button>
     <button data-selects="turtle">Turtle</button>
-    <a class="playground" target="_blank"></a>
+    <a class="playground" target="_blank" href="#">PGPG</a>
   </div>
   <pre class="compacted input selected nohighlight" data-transform="updateExample">
   <!--
@@ -4946,7 +4949,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <button data-selects="expanded">Expanded (Result)</button>
     <button data-selects="statements">Statements</button>
     <button data-selects="turtle">Turtle</button>
-    <a class="playground" target="_blank"></a>
+    <a class="playground" target="_blank" href="#">PG</a>
   </div>
   <pre class="compacted input selected nohighlight" data-transform="updateExample">
   <!--
@@ -5045,7 +5048,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -5261,7 +5264,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="turtle">Turtle (drops direction)</button>
       <button data-selects="turtle-dt">Turtle (with datatype)</button>
       <button data-selects="turtle-bn">Turtle (with bnode structure)</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -5474,7 +5477,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <button data-selects="expanded">Expanded (Result)</button>
     <button data-selects="statements">Statements</button>
     <button data-selects="turtle">Turtle</button>
-    <a class="playground" target="_blank"></a>
+    <a class="playground" target="_blank" href="#">PG</a>
   </div>
   <pre class="compacted input selected nohighlight" data-transform="updateExample">
   <!--
@@ -5550,7 +5553,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <button data-selects="expanded">Expanded (Result)</button>
     <button data-selects="statements">Statements</button>
     <button data-selects="turtle">Turtle</button>
-    <a class="playground" target="_blank"></a>
+    <a class="playground" target="_blank" href="#">PG</a>
   </div>
   <pre class="compacted input selected nohighlight" data-transform="updateExample">
   <!--
@@ -5635,7 +5638,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <button data-selects="expanded">Expanded (Result)</button>
     <button data-selects="statements">Statements</button>
     <button data-selects="turtle">Turtle</button>
-    <a class="playground" target="_blank"></a>
+    <a class="playground" target="_blank" href="#">PG</a>
   </div>
   <pre class="compacted input selected nohighlight" data-transform="updateExample">
   <!--
@@ -5749,7 +5752,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <button data-selects="expanded">Expanded (Result)</button>
     <button data-selects="statements">Statements</button>
     <button data-selects="turtle">Turtle</button>
-    <a class="playground" target="_blank"></a>
+    <a class="playground" target="_blank" href="#">PG</a>
   </div>
   <pre class="compacted input selected nohighlight" data-transform="updateExample">
   <!--
@@ -5823,7 +5826,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <button data-selects="expanded">Expanded (Result)</button>
     <button data-selects="statements">Statements</button>
     <button data-selects="turtle">Turtle</button>
-    <a class="playground" target="_blank"></a>
+    <a class="playground" target="_blank" href="#">PG</a>
   </div>
   <pre class="compacted input selected nohighlight" data-transform="updateExample">
   <!--
@@ -5937,7 +5940,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <button data-selects="expanded">Expanded (Result)</button>
     <button data-selects="statements">Statements</button>
     <button data-selects="turtle">Turtle</button>
-    <a class="playground" target="_blank"></a>
+    <a class="playground" target="_blank" href="#">PG</a>
   </div>
   <pre class="compacted input selected changed"
        data-content-type="application/json"
@@ -6103,7 +6106,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <button data-selects="expanded">Expanded (Result)</button>
     <button data-selects="statements">Statements</button>
     <button data-selects="turtle">Turtle</button>
-    <a class="playground" target="_blank"></a>
+    <a class="playground" target="_blank" href="#">PG</a>
   </div>
   <pre class="compacted input selected nohighlight" data-transform="updateExample">
   <!--
@@ -6183,7 +6186,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <button data-selects="expanded">Expanded (Result)</button>
     <button data-selects="statements">Statements</button>
     <button data-selects="turtle">Turtle</button>
-    <a class="playground" target="_blank"></a>
+    <a class="playground" target="_blank" href="#">PG</a>
   </div>
   <pre class="compacted input selected nohighlight" data-transform="updateExample">
   <!--
@@ -6299,7 +6302,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -6397,7 +6400,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -6531,7 +6534,8 @@ the data type to be specified explicitly with each piece of data.</p>
          data-result-for="#defining-property-nesting-expanded"
          data-context="#defining-property-nesting-context"
          data-compact
-         target="_blank"></a>
+         target="_blank"
+         href="#">PG</a>
     </div>
     <pre class="compacted result selected nohighlight" data-transform="updateExample">
     <!--
@@ -6616,7 +6620,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -6726,7 +6730,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -6839,7 +6843,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -6965,7 +6969,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -7103,7 +7107,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -7241,7 +7245,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -7378,7 +7382,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -7507,7 +7511,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected" data-transform="updateExample">
     <!--
@@ -7588,7 +7592,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -7661,7 +7665,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -7743,7 +7747,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -7864,7 +7868,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -7974,7 +7978,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -8107,7 +8111,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -8210,7 +8214,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -8309,7 +8313,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -8473,7 +8477,8 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
       <a class="playground" target="_blank"
-         data-result-for="#included-blocks-to-be-flattened"></a>
+         data-result-for="#included-blocks-to-be-flattened"
+         href="#">PG</a>
     </div>
     <pre class="flattened result selected" data-transform="updateExample"
          data-flatten
@@ -8576,7 +8581,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="flattened">Flattened</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -8700,7 +8705,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight"
          data-transform="updateExample"
@@ -8784,7 +8789,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="flattened">Flattened</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight"
          data-base="http://example.org/"
@@ -8891,7 +8896,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="flattened">Flattened</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample"
          data-base="http://example.org/">
@@ -9003,7 +9008,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="trig">TriG</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -9129,7 +9134,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="trig">TriG</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -9208,7 +9213,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="trig">TriG</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -9315,7 +9320,7 @@ the data type to be specified explicitly with each piece of data.</p>
         <button data-selects="expanded">Expanded (Result)</button>
         <button data-selects="statements">Statements</button>
         <button data-selects="trig">TriG</button>
-        <a class="playground" target="_blank"></a>
+        <a class="playground" target="_blank" href="#">PG</a>
       </div>
       <pre class="compacted input selected nohighlight" data-transform="updateExample">
       <!--
@@ -9409,7 +9414,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="trig">TriG</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -9536,7 +9541,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="trig">TriG</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -9665,7 +9670,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="trig">TriG</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -9811,7 +9816,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="expanded">Expanded (Result)</button>
       <button data-selects="statements">Statements</button>
       <button data-selects="trig">TriG</button>
-      <a class="playground" target="_blank"></a>
+      <a class="playground" target="_blank" href="#">PG</a>
     </div>
     <pre class="compacted input selected nohighlight" data-transform="updateExample">
     <!--
@@ -10028,7 +10033,8 @@ the data type to be specified explicitly with each piece of data.</p>
       <button data-selects="statements">Statements</button>
       <button data-selects="turtle">Turtle</button>
       <a class="playground" target="_blank"
-         data-result-for="#sample-json-ld-document-to-be-expanded"></a>
+         data-result-for="#sample-json-ld-document-to-be-expanded"
+         href="#">PG</a>
     </div>
     <pre class="expanded result selected" data-transform="updateExample"
          data-result-for="Sample JSON-LD document to be expanded">
@@ -10136,7 +10142,8 @@ the data type to be specified explicitly with each piece of data.</p>
       <!--<a class="playground" target="_blank"
          data-result-for="#sample-expanded-json-ld-document"
          data-context="#sample-context"
-         data-compact></a>-->
+         data-compact
+         href="#">PG</a>-->
     </div>
     <pre class="selected original" data-transform="updateExample"
          data-result-for="Sample expanded JSON-LD document"
@@ -10820,7 +10827,8 @@ the data type to be specified explicitly with each piece of data.</p>
       <a class="playground" target="_blank"
          data-result-for="#sample-expanded-json-ld-document-to-be-flattened"
          data-context="#sample-expanded-json-ld-document-to-be-flattened"
-         data-flatten></a>
+         data-flatten
+         href="#">PG</a>
     </div>
     <pre class="selected original" data-transform="updateExample"
          data-flatten
@@ -10938,7 +10946,8 @@ the data type to be specified explicitly with each piece of data.</p>
       <a class="playground" target="_blank"
          data-result-for="#sample-flattened-library-objects"
          data-frame="#sample-library-frame"
-         data-flatten></a>
+         data-flatten
+         href="#">PG</a>
     </div>
     <pre class="selected original nohighlight" data-transform="updateExample"
          title="Framed library objects"

--- a/index.html
+++ b/index.html
@@ -124,7 +124,6 @@
       group: "wg/json-ld",
       wgPublicList: "public-json-ld-wg",
 
-     processVersion: 2018,
       maxTocLevel: 4,
       alternateFormats: [ {uri: "json-ld11.epub", label: "EPUB"} ]
   };

--- a/index.html
+++ b/index.html
@@ -122,7 +122,9 @@
       ],
 
       group: "wg/json-ld",
-      processVersion: 2018,
+      wgPublicList: "public-json-ld-wg",
+
+     processVersion: 2018,
       maxTocLevel: 4,
       alternateFormats: [ {uri: "json-ld11.epub", label: "EPUB"} ]
   };

--- a/index.html
+++ b/index.html
@@ -121,21 +121,7 @@
           note:       "v1.0" }
       ],
 
-      // name of the WG
-      wg:           "JSON-LD Working Group",
-
-      // URI of the public WG page
-      wgURI:        "https://www.w3.org/2018/json-ld-wg/",
-
-      // name (with the @w3c.org) of the public mailing to which comments are due
-      wgPublicList: "public-json-ld-wg",
-
-      // URI of the patent status for this WG, for Rec-track documents
-      // !!!! IMPORTANT !!!!
-      // This is important for Rec-track documents, do not copy a patent URI from a random
-      // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
-      // Team Contact.
-      wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/107714/status",
+      group: "wg/json-ld",
       processVersion: 2018,
       maxTocLevel: 4,
       alternateFormats: [ {uri: "json-ld11.epub", label: "EPUB"} ]

--- a/index.html
+++ b/index.html
@@ -438,9 +438,7 @@
     <p>This document uses the following terms as defined in external specifications
       and defines terms specific to JSON-LD.</p>
 
-    <div data-include="common/terms.html"
-         data-oninclude="restrictReferences">
-    </div>
+    <div data-include="common/terms.html"></div>
   </section>
 
   <section class="informative">

--- a/index.html
+++ b/index.html
@@ -503,7 +503,7 @@
       intrinsic meaning.
       Literal values, such as <a>strings</a> and <a>numbers</a>, are also considered <a>resources</a>,
       and JSON-LD distinguishes between <a>node objects</a> and <a>value objects</a> to distinguish between the different
-      kinds of <a>resource</a>.</p>
+      kinds of <a>resources</a>.</p>
     <p>This simple data model is incredibly
       flexible and powerful, capable of modeling almost any kind of
       data. For a deeper explanation of the data model, see
@@ -2399,7 +2399,7 @@
     </pre>
   </aside>
 
-  <p>If <code>@vocab</code> is used but certain keys in an
+  <p>If <code>@vocab</code> is used but certain keys in a
     <a>map</a> should not be expanded using
     the vocabulary <a>IRI</a>, a <a>term</a> can be explicitly set
     to <a>null</a> in the <a>context</a>. For instance, in the
@@ -2874,7 +2874,7 @@
     or if their <a>expanded term definition</a> contains
     a <code>@prefix</code> <a>entry</a> with the value <code>true</code>.
     If a <a>simple term definition</a> does not end with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
-    or a <a>expanded term definition</a> contains
+    or an <a>expanded term definition</a> contains
     a <code>@prefix</code> <a>entry</a> with the value <code>false</code>,
     the term will not be used for either expanding <a>compact IRIs</a> or compacting <a>IRIs</a> to <a>compact IRIs</a>.</p>
 
@@ -3136,7 +3136,7 @@
   <p class="changed">Unless the <a>processing mode</a> is set to `json-ld-1.0`,
     aliases of <a>keywords</a> are either <a data-lt="simple term definition">simple term definitions</a>,
     where the value is a <a>keyword</a>,
-    or a <a>expanded term definitions</a> with an `@id` <a>entry</a> and optionally an `@protected` <a>entry</a>;
+    or an <a>expanded term definitions</a> with an `@id` <a>entry</a> and optionally an `@protected` <a>entry</a>;
     no other entries are allowed.
     There is also an exception for aliases of <code>@type</code>,
     as indicated above.
@@ -3512,7 +3512,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
 
   <p>Scoping on <code>@type</code> is useful when common properties are used to
     relate things of different types, where the vocabularies in use within
-    different entities calls for different context scoping. For example,
+    different entities call for different context scoping. For example,
     <code>hasPart</code>/<code>partOf</code> may be common terms used in a document, but mean
     different things depending on the context.
     A <a>type-scoped context</a> is only in effect for the <a>node object</a> on which
@@ -5084,7 +5084,7 @@ the data type to be specified explicitly with each piece of data.</p>
   </aside>
 
   <p>The example above would associate the <code>ja</code> language
-    tag with the two <a>strings</a> <em lang="ja">花澄</em> and <em lang="ja">科学者</em>
+    tag with the two <a>strings</a> <em lang="ja">花澄</em> and <em lang="ja">科学者</em>.
     <a data-cite="BCP47#section-2">Languages tags</a> are defined in [[BCP47]].
     The <a>default language</a> applies to all
     <a>string</a> values that are not <a href="#type-coercion">type coerced</a>.</p>
@@ -5608,7 +5608,7 @@ the data type to be specified explicitly with each piece of data.</p>
   </pre>
 </aside>
 
-<p class="note">The example shown above would generates statement, again with
+<p class="note">The example shown above would generate multiple statements, again with
   no inherent order.</p>
 
 <p>Although multiple values of a property are typically of the same type,
@@ -7046,7 +7046,7 @@ the data type to be specified explicitly with each piece of data.</p>
 <section class="informative"><h2>Indexed Values</h2>
 
 <p>Sometimes multiple property values need to be accessed
-  in a more direct fashion than iterating though multiple array values. JSON-LD
+  in a more direct fashion than iterating through multiple array values. JSON-LD
   provides an indexing mechanism to allow the use of an intermediate <a>map</a>
   to associate specific indexes with associated values.</p>
 
@@ -11552,7 +11552,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <li>A <a>node</a> having an outgoing edge MUST be an <a>IRI</a> or a
       <a>blank node</a>.</li>
     <li>A <a>graph</a> MUST NOT contain unconnected <a>nodes</a>,
-      i.e., nodes which are not connected by an <a>property</a> to any other <a>node</a>.
+      i.e., nodes which are not connected by a <a>property</a> to any other <a>node</a>.
       <pre class="illegal-example"
           data-transform="updateExample"
           data-ignore
@@ -11585,7 +11585,7 @@ the data type to be specified explicitly with each piece of data.</p>
       as a <a>typed value</a> with type <code>xsd:string</code>), a <a>number</a>
       (<a>numbers</a> with a non-zero fractional part, i.e., the result of a modulo&#8209;1 operation,
       <span class="changed">or which are too large to represent as integers
-        (see <a data-cite="JSON-LD11-API#data-round-tripping">Data Round Tripping</a>) in [[JSON-LD11-API]]),</span>
+        (see <a data-cite="JSON-LD11-API#data-round-tripping">Data Round Tripping</a> in [[JSON-LD11-API]]),</span>
       are interpreted as <a>typed values</a> with type <code>xsd:double</code>, all other
       <a>numbers</a> are interpreted as <a>typed values</a>
       with type <code>xsd:integer</code>), <code>true</code> or <code>false</code> (which are interpreted as
@@ -12198,7 +12198,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <h2>Property-based Index Maps</h2>
 
     <p>A property-based <a>index map</a> is a variant of <a>index map</a>
-      were indexes are semantically preserved in the graph as property values.
+      where indexes are semantically preserved in the graph as property values.
       A property-based <a>index map</a> may be used as a term value within a <a>node object</a>
       if the <a>term</a> is defined with <code>@container</code> set to <code>@index</code>,
       or an array containing both <code>@index</code> and <code>@set</code>,
@@ -12260,7 +12260,7 @@ the data type to be specified explicitly with each piece of data.</p>
       or <a>strings</a> which expand to <a>node objects</a>.</p>
 
     <p>If the value contains a property expanding to <code>@type</code>, and its value
-      is contains the referencing key after suitable expansion of both the referencing key
+      contains the referencing key after suitable expansion of both the referencing key
       and the value, then the <a>node object</a> already contains the type. Otherwise, the property from the value is
       added as a <code>@type</code> of the <a>node object</a> value when expanding.</p>
   </section>
@@ -12467,7 +12467,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <a>keyword</a> aliases MAY be used instead of the corresponding <a>keyword</a>, except for `@context`.
     The `@context` <a>keyword</a> MUST NOT be aliased.
     Within <a>local contexts</a> and <a>expanded term definitions</a>,
-    <a>keyword</a> aliases MAY NOT used.</p>
+    <a>keyword</a> aliases MAY NOT be used.</p>
 
   <dl data-sort>
     <dt><code>@base</code></dt><dd>
@@ -12532,7 +12532,7 @@ the data type to be specified explicitly with each piece of data.</p>
       <a>node object</a>, <a>value object</a>, <a>graph object</a>, <a>set object</a>, or <a>list object</a>.
       Its value MUST be a <a>string</a>.
       <p>The unaliased <code>@index</code> MAY be used as the value of the <code>@container</code> key within an <a>expanded term definition</a>
-        and as an entry in a <a>expanded term definition</a>, where the value an <a>IRI</a>,
+        and as an entry in an <a>expanded term definition</a>, where the value an <a>IRI</a>,
         a <a>compact IRI</a>, or a <a>term</a>.</p>
       <p>See <a class="sectionRef" href="#index-maps"></a>, and
         <a class="sectionRef" href="#property-based-data-indexing"></a> for a further discussion.</p>
@@ -13076,13 +13076,13 @@ the data type to be specified explicitly with each piece of data.</p>
         <dt>Alice</dt>
         <dd>an RDF literal with no datatype or language.</dd>
         <dt>weiblich | de</dt>
-        <dd>an language-tagged string with the value "weiblich" and <a>language tag</a> "de".</dd>
+        <dd>a <a>language-tagged string</a> with the value "weiblich" and <a>language tag</a> "de".</dd>
         <dt>female | en</dt>
-        <dd>an language-tagged string with the value "female" and <a>language tag</a> "en".</dd>
+        <dd>a <a>language-tagged string</a> with the value "female" and <a>language tag</a> "en".</dd>
       </dl>
 
       <p>The second and third boxes describe two <a>named graphs</a>, with the graph names
-        "http://example.com/graphs/1" and "http://example.com/graphs/1", respectively.</p>
+        "http://example.com/graphs/1" and "http://example.com/graphs/2", respectively.</p>
       <p>The second box consists of two resources:
         <code>http://example.com/people/alice</code> and <code>http://example.com/people/bob</code>
         related by the <code>schema:parent</code> relationship, and names the
@@ -13741,6 +13741,13 @@ the data type to be specified explicitly with each piece of data.</p>
     <li>Fixed typo in <a href="#frame-objects" class="sectionRef"></a>,
       which was unintentionally diverging from the normative description of the `@embed` keyword in [[[JSON-LD11-FRAMING]]].
       This is in response to <a href="https://github.com/w3c/json-ld-syntax/issues/358">Issue 358</a>.</li>
+  </ul>
+</section>
+<section class="appendix informative" id="changes-from-rec1">
+  <h2>Changes since Recommendation of 16 July 2020</h2>
+  <ul>
+    <li>Misclaneous spelling and grammar fixes.</li>
+    <li>Regenerated definition list, which does not attempt to filter out unused definitions.</li>
   </ul>
 </section>
 


### PR DESCRIPTION
* Use respec-w3c instead of respec-w3c-comman.
* Update playground links to not be flagged by ReSpec.
* Update ReSpec configuration to use group: "wg/json-ld" instead of separate wg* attributes.
* Remove old dependence on ReSpec definition list and non-existant "end" subscription.
* Miscellaneous spelling and grammar fixes suggested by @shujikamitsuna.

Fixes #364.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/365.html" title="Last updated on Nov 13, 2020, 10:50 PM UTC (ac5839f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/365/87b7069...ac5839f.html" title="Last updated on Nov 13, 2020, 10:50 PM UTC (ac5839f)">Diff</a>