### PR TITLE
Fix @direction not listed under context definition's definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -12299,6 +12299,7 @@ the data type to be specified explicitly with each piece of data.</p>
     keys MUST be either <a>terms</a>, <a>compact IRIs</a>, <a>IRIs</a>,
     or one of the <a>keywords</a>
     <code>@base</code>,
+    <code class="changed">@direction</code>,
     <code class="changed">@import</code>,
     <code>@language</code>,
     <code class="changed">@propagate</code>,


### PR DESCRIPTION
While @direction may be used in a context definition it was only listed under context definition's conditional cases not under context definition's definition.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kibubu/json-ld-syntax/pull/439.html" title="Last updated on Aug 2, 2024, 3:49 PM UTC (41e8195)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/439/7bb0d85...Kibubu:41e8195.html" title="Last updated on Aug 2, 2024, 3:49 PM UTC (41e8195)">Diff</a>