### PR TITLE
fix typo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -3331,7 +3331,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
 
 <section class="informative changed"><h2>Scoped Contexts</h2>
 
-  <p>An <a>expanded term definition</a> can include a <code>@context</code>
+  <p>An <a>expanded term definition</a> can include an <code>@context</code>
     property, which defines a <a>context</a> (a <a>scoped context</a>) for
     <a data-lt="JSON-LD value">values</a> of properties defined using that <a>term</a>.
     When used for a <a>property</a>, this is called a <a>property-scoped context</a>.


### PR DESCRIPTION
Changes the one instance of `a <code>@context` to `an <code>@context`, to match the other six instances of the latter.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/json-ld-syntax/pull/448.html" title="Last updated on Nov 22, 2024, 7:37 PM UTC (5eb3d3c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/448/bf79c62...TallTed:5eb3d3c.html" title="Last updated on Nov 22, 2024, 7:37 PM UTC (5eb3d3c)">Diff</a>