### PR TITLE
Fix typo in example 128 on compacting

### DIFF
--- a/index.html
+++ b/index.html
@@ -10203,7 +10203,7 @@ the data type to be specified explicitly with each piece of data.</p>
       }
       -->
       </pre>
-      <p>The compaction algorithm will shorten all vocabulary-relative IRIs that begin with <code>http://xmlns.com/foaf/0.1/</code>:</p>
+      <p>The compaction algorithm will shorten all vocabulary-relative IRIs that begin with <code>http://example.org/</code>:</p>
       <pre class="compacted result nohighlight" data-transform="updateExample"
            data-result-for="Compacting using a default vocabulary-expanded"
            data-context="Compacting using a default vocabulary-context"


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bretelerjmw/json-ld-syntax/pull/450.html" title="Last updated on Feb 7, 2025, 6:00 PM UTC (57bca38)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/450/bf79c62...bretelerjmw:57bca38.html" title="Last updated on Feb 7, 2025, 6:00 PM UTC (57bca38)">Diff</a>