### PR TITLE
Remove the `<ins>` tag

### DIFF
--- a/common/terms.html
+++ b/common/terms.html
@@ -383,8 +383,8 @@
     Its value is either a string (<dfn data-cite="JSON-LD11#dfn-simple-term-definition" data-lt="simple term definition|simple term" data-lt-noDefault>simple term definition</dfn>),
     expanding to an <a>IRI</a>,
     or a map (<a>expanded term definition</a>).
-    <ins cite="#change_api_638"><br/>
-    For <a data-cite="JSON-LD11-API#context-processing-algorithms">context processing</a>, <a>term definition</a> values are converted internally to a dedicated data structure that is easier to process.</ins>
+    <br/>
+    For <a data-cite="JSON-LD11-API#context-processing-algorithms">context processing</a>, <a>term definition</a> values are converted internally to a dedicated data structure that is easier to process.
   </dd>
   <dt class="changed"><dfn data-cite="JSON-LD11#dfn-type-map">type map</dfn></dt><dd class="changed">
     A <a>type map</a> is a <a>map</a> value of a <a>term</a>

--- a/common/terms.html
+++ b/common/terms.html
@@ -383,7 +383,6 @@
     Its value is either a string (<dfn data-cite="JSON-LD11#dfn-simple-term-definition" data-lt="simple term definition|simple term" data-lt-noDefault>simple term definition</dfn>),
     expanding to an <a>IRI</a>,
     or a map (<a>expanded term definition</a>).
-    <br/>
     For <a data-cite="JSON-LD11-API#context-processing-algorithms">context processing</a>, <a>term definition</a> values are converted internally to a dedicated data structure that is easier to process.
   </dd>
   <dt class="changed"><dfn data-cite="JSON-LD11#dfn-type-map">type map</dfn></dt><dd class="changed">

--- a/index.html
+++ b/index.html
@@ -440,14 +440,6 @@
       and defines terms specific to JSON-LD.</p>
 
 
-    <div id="change_api_638" class="candidate correction">
-      <span class="marker">Candidate Correction 1</span>
-      <p>Change the type of <a>term definition</a> from <a>array</a> to <a>map</a> in <a>active context</a>,
-        to be consistent with the way it is used in the algorithms.
-        For more information, refer to <a href="https://github.com/w3c/json-ld-api/issues/630">issue 630</a>.
-      </p>
-    </div>
-
     <div data-include="common/terms.html"></div>
   </section>
 
@@ -13888,8 +13880,10 @@ the data type to be specified explicitly with each piece of data.</p>
     <li>Allow further structured extensions of `application/ld+json` by using
       `+ld+json` as a structured media extension. See <a href="#structured-extension-ld-json"></a>.</li>
     <li>Use <a>code point order</a> as a better definition for the more vague "lexicographical order".</li>
-    <li>2025-06-04: Clarifiy language about <a>term definitions</a>,
-      as described in <a href="#change_api_638">Candidate Correction 1</a></li>
+    <li>2025-06-04: Clarify language about <a>term definitions</a>:
+      change the type of <a>term definition</a> from <a>array</a> to <a>map</a> in <a>active context</a>,
+      to be consistent with the way it is used in the algorithms.
+      For more information, refer to <a href="https://github.com/w3c/json-ld-api/issues/630">issue 630</a>.</li>
   </ul>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -13881,7 +13881,7 @@ the data type to be specified explicitly with each piece of data.</p>
       `+ld+json` as a structured media extension. See <a href="#structured-extension-ld-json"></a>.</li>
     <li>Use <a>code point order</a> as a better definition for the more vague "lexicographical order".</li>
     <li>2025-06-04: Clarify language about <a>term definitions</a>.
-      For more information, refer to <a href="https://github.com/w3c/json-ld-api/issues/630">issue 630</a>.</li>
+      For more information, refer to <a href="https://github.com/w3c/json-ld-api/issues/630">issue json-ld-api#630</a>.</li>
   </ul>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -13880,9 +13880,7 @@ the data type to be specified explicitly with each piece of data.</p>
     <li>Allow further structured extensions of `application/ld+json` by using
       `+ld+json` as a structured media extension. See <a href="#structured-extension-ld-json"></a>.</li>
     <li>Use <a>code point order</a> as a better definition for the more vague "lexicographical order".</li>
-    <li>2025-06-04: Clarify language about <a>term definitions</a>:
-      change the type of <a>term definition</a> from <a>array</a> to <a>map</a> in <a>active context</a>,
-      to be consistent with the way it is used in the algorithms.
+    <li>2025-06-04: Clarify language about <a>term definitions</a>.
       For more information, refer to <a href="https://github.com/w3c/json-ld-api/issues/630">issue 630</a>.</li>
   </ul>
 </section>


### PR DESCRIPTION
Following https://github.com/w3c/json-ld-api/issues/676.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/479.html" title="Last updated on Jan 23, 2026, 1:48 PM UTC (d6677b8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/479/769369f...d6677b8.html" title="Last updated on Jan 23, 2026, 1:48 PM UTC (d6677b8)">Diff</a>