### PR TITLE
Editorial: remove comma in section 4.1.8 (issue #477)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3428,7 +3428,7 @@ In this example, the <a>compact IRI</a> form is used in two different ways.
     and is used to define a node describing one of Manu's interests
     where those <a>properties</a> now come from the FOAF vocabulary.</p>
 
-  <p>Expanding this document, uses a combination of terms defined in the outer context,
+  <p>Expanding this document uses a combination of terms defined in the outer context,
     and those defined specifically for that term in a <a>property-scoped context</a>.</p>
 
   <p>Scoping can also be performed using a term used as a value of <code>@type</code>:</p>


### PR DESCRIPTION
Update spec text in 4.1.8 to remove the extraneous comma after \"Expanding this document\" per editorial issue 477.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/pull/481.html" title="Last updated on Feb 4, 2026, 12:46 PM UTC (26ba0bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-syntax/481/769369f...26ba0bb.html" title="Last updated on Feb 4, 2026, 12:46 PM UTC (26ba0bb)">Diff</a>